### PR TITLE
Support :ignored-file config key

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cryogen-core "0.1.8"
+(defproject cryogen-core "0.1.9-SNAPSHOT"
             :description "Cryogen's compiler"
             :url "https://github.com/lacarmen/cryogen-core"
             :license {:name "Eclipse Public License"

--- a/src/cryogen_core/io.clj
+++ b/src/cryogen_core/io.clj
@@ -11,9 +11,16 @@
       (.toURI)
       (io/file)))
 
-(defn find-assets [f ext]
+(defn ignore [ignored-files]
+  (fn [file]
+    (let [name    (.getName file)
+          matches (map #(re-find % name) ignored-files)]
+      (not (some seq matches)))))
+
+(defn find-assets [f ext ignored-files]
   (->> (get-resource f)
        file-seq
+       (filter (ignore ignored-files))
        (filter (fn [file] (-> file .getName (.endsWith ext))))))
 
 (defn create-folder [folder]

--- a/src/cryogen_core/sitemap.clj
+++ b/src/cryogen_core/sitemap.clj
@@ -13,13 +13,13 @@
 (defn loc [f]
   (-> f (.getAbsolutePath) (.split "resources/public/") second))
 
-(defn generate [site-url]
+(defn generate [site-url ignored-files]
   (with-out-str
     (emit
       {:tag :urlset
        :attrs {:xmlns "http://www.sitemaps.org/schemas/sitemap/0.9"}
        :content
-        (for [f (find-assets "public" ".html")]
+       (for [f (find-assets "public" ".html" ignored-files)]
          {:tag :url
           :content
           [{:tag :loc

--- a/src/cryogen_core/watcher.clj
+++ b/src/cryogen_core/watcher.clj
@@ -1,21 +1,26 @@
 (ns cryogen-core.watcher
-  (:require [clojure.java.io :refer [file]]))
+  (:require [clojure.java.io :refer [file]]
+            [cryogen-core.io :refer [ignore]]))
 
-(defn get-assets [root]
-  (file-seq (file root)))
+(defn get-assets [root ignored-files]
+  (->> root
+       file
+       file-seq
+       (filter #(not (.isDirectory %)))
+       (filter (ignore ignored-files))))
 
-(defn sum-times [path]
-  (->> (get-assets path) (map #(.lastModified %)) (reduce +)))
+(defn sum-times [path ignored-files]
+  (->> (get-assets path ignored-files) (map #(.lastModified %)) (reduce +)))
 
-(defn watch-assets [root action]
-  (loop [times (sum-times root)]
+(defn watch-assets [root ignored-files action]
+  (loop [times (sum-times root ignored-files)]
     (Thread/sleep 300)
-    (let [new-times (sum-times root)]
+    (let [new-times (sum-times root ignored-files)]
       (when-not (= times new-times)
         (action))
       (recur new-times))))
 
-(defn start-watcher! [root action]
-  (doto (Thread. #(watch-assets root action))
+(defn start-watcher! [root ignored-files action]
+  (doto (Thread. #(watch-assets root ignored-files action))
     (.setDaemon true)
     (.start)))


### PR DESCRIPTION
Prevent the compiler attempting to process files defined by a list of regexps. By default ignore emacs and vi backup files.

I'm not sure how to manage versions here so I've left in the bumped snapshot versions I've been using for testing. Let me know if this needs fixing, and what the right way to set versions in PRs would be.

See also lacarmen/cryogen#42
