### PR TITLE
Compile sass with compass when available

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -321,9 +321,9 @@
     (rss/make-filtered-channels public config posts-by-tag)
     (println (blue "compiling sass"))
     (sass/compile-sass->css!
-     (str "resources/templates/" sass-src)
-     (str "resources/public" blog-prefix "/" sass-dest)
-     ignored-files)))
+     {:src-sass (str "resources/templates/" sass-src)
+      :dest-sass (str "resources/public" blog-prefix "/" sass-dest)
+      :ignored-files ignored-files})))
 
 (defn compile-assets-timed []
   (time

--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -321,9 +321,10 @@
     (rss/make-filtered-channels public config posts-by-tag)
     (println (blue "compiling sass"))
     (sass/compile-sass->css!
-     {:src-sass (str "resources/templates/" sass-src)
-      :dest-sass (str "resources/public" blog-prefix "/" sass-dest)
-      :ignored-files ignored-files})))
+     {:src-sass sass-src
+      :dest-sass (str "../public" blog-prefix "/" sass-dest)
+      :ignored-files ignored-files
+      :base-dir "resources/templates/"})))
 
 (defn compile-assets-timed []
   (time

--- a/src/cryogen_core/sass.clj
+++ b/src/cryogen_core/sass.clj
@@ -1,6 +1,7 @@
 (ns cryogen-core.sass
   (:require [clojure.java.shell :as shell]
             [clojure.java.io :as io]
+            [text-decoration.core :refer :all]
             [cryogen-core.io :refer [ignore match-re-filter]]))
 
 (defmacro sh
@@ -63,7 +64,8 @@ the command. Shows you any problems it comes across when compiling. "
                ;; no problems in sass compilation
                (println "Successfully compiled:" a-file)
                ;; else I show the error
-               (println (:err result))))))
+               (println (red (:err result))
+                        (red (:out result)))))))
         ;; Else I prompt to install Sass
         (println "Sass seems not to be installed, but you have scss / sass files in "
                  src-sass

--- a/src/cryogen_core/sass.clj
+++ b/src/cryogen_core/sass.clj
@@ -47,9 +47,9 @@
   "Given a directory src-sass, looks for all sass files and compiles them into
 dest-sass. Prompts you to install sass if he finds sass files and can't find
 the command. Shows you any problems it comes across when compiling. "
-  [src-sass
-   dest-sass
-   ignored-files]
+  [{:keys [src-sass
+           dest-sass
+           ignored-files]}]
   (let [sass-files (find-sass-files src-sass ignored-files)]
     (if (seq sass-files)
       ;; I found sass files,

--- a/src/cryogen_core/sass.clj
+++ b/src/cryogen_core/sass.clj
@@ -22,9 +22,9 @@
 (defn find-sass-files
   "Given a Diretory, gets files, Filtered to those having scss or sass
   extention. Ignores files matching any ignored regexps."
-  [dir ignored-files]
+  [base-dir dir ignored-files]
   (let [filename-filter (match-re-filter #"(?i:s[ca]ss$)")]
-    (->> (.listFiles (io/file dir) filename-filter)
+    (->> (.listFiles (io/file base-dir dir) filename-filter)
          (filter #(not (.isDirectory %)))
          (filter (ignore ignored-files))
          (map #(.getName %)))))
@@ -33,15 +33,14 @@
   "Given a sass file which might be in src-sass directory,
   output the resulting css in dest-sass. All error handling is
     done by sh / launching the sass command."
-  [sass-file
-   src-sass
-   dest-sass
-   compass?]
-  (sh "sass"
-      "--update"
-      (when compass? "--compass")
-      (str src-sass "/" sass-file)
-      (str dest-sass "/" )))
+  [{:keys [src-sass
+           dest-sass
+           base-dir]}]
+  (shell/with-sh-dir base-dir
+    (sh "sass"
+        "--update"
+        (when (compass-installed?) "--compass")
+        (str src-sass ":" dest-sass))))
 
 (defn compile-sass->css!
   "Given a directory src-sass, looks for all sass files and compiles them into
@@ -49,24 +48,22 @@ dest-sass. Prompts you to install sass if he finds sass files and can't find
 the command. Shows you any problems it comes across when compiling. "
   [{:keys [src-sass
            dest-sass
-           ignored-files]}]
-  (let [sass-files (find-sass-files src-sass ignored-files)]
-    (if (seq sass-files)
+           ignored-files
+           base-dir] :as opts}]
+  (when-let [sass-files (seq (find-sass-files base-dir src-sass ignored-files))]
+    (if (sass-installed?)
       ;; I found sass files,
       ;; If sass is installed
-      (if (sass-installed?)
-        (let [compass? (compass-installed?)]
-         ;; I compile all files
-         (doseq [a-file sass-files]
-           (println "Compiling Sass File:" a-file src-sass dest-sass)
-           (let [result   (compile-sass-file! a-file src-sass dest-sass compass?)]
-             (if (zero? (:exit result))
-               ;; no problems in sass compilation
-               (println "Successfully compiled:" a-file)
-               ;; else I show the error
-               (println (red (:err result))
-                        (red (:out result)))))))
-        ;; Else I prompt to install Sass
-        (println "Sass seems not to be installed, but you have scss / sass files in "
-                 src-sass
-                 " - You might want to install it here: sass-lang.com")))))
+      (do
+        (println "Compiling Sass Files:" src-sass dest-sass)
+        (let [result (compile-sass-file! opts)]
+          (if (zero? (:exit result))
+            ;; no problems in sass compilation
+            (println "Successfully compiled sass files")
+            ;; else I show the error
+            (println (red (:err result))
+                     (red (:out result))))))
+      ;; Else I prompt to install Sass
+      (println "Sass seems not to be installed, but you have scss / sass files in "
+               src-sass
+               " - You might want to install it here: sass-lang.com"))))


### PR DESCRIPTION
This pull request adds the `--compass` argument to the command line that calls `sass` if the `compass` binary is available on the user's `$PATH`. 

While testing this change with a cryogen-generated blog and some non-trivial SASS files, it was necessary also to run the sass compiler in the `resources/templates` directory and to change the paths relative to that. The `sass --help` also mentions that when using `--update` (as we do here), we should be using `source-dir:destination-dir` form of arguments (which means no need to pass every sass file, so could be marginally faster). It's not unusual for sass directories to have one main `screen.scss` file and lots of included utils with names starting with `_` which don't themselves generate any css - letting the sass compiler worry about all that reduces complexity in this codebase slightly.

If there are any changes that need to be made, including any rebasing of the commits, I'm very happy to do that.