### PR TITLE
Modification to allow the generated rss xml to pass xsd validation.

### DIFF
--- a/src/cryogen_core/rss.clj
+++ b/src/cryogen_core/rss.clj
@@ -5,7 +5,7 @@
   (:import java.util.Date))
 
 
-(defn posts-to-items [site-url author posts]
+(defn posts-to-items [site-url posts]
   (map
     (fn [{:keys [uri title content date]}]
       (let [link (str (if (.endsWith site-url "/") (apply str (butlast site-url)) site-url) uri)]
@@ -13,8 +13,7 @@
          :link        link
          :title       title
          :description content
-         :pubDate     date
-         :author      author}))
+         :pubDate     date}))
     posts))
 
 (defn make-channel [config posts]
@@ -24,9 +23,8 @@
              {:title         (:site-title config)
               :link          (:site-url config)
               :description   (:description config)
-              :lastBuildDate (Date.)
-              :author        (:author config)})
-    (posts-to-items (:site-url config) (:author config) posts)))
+              :lastBuildDate (Date.)})
+    (posts-to-items (:site-url config) posts)))
 
 (defn make-filtered-channels [public {:keys [rss-filters blog-prefix] :as config} posts-by-tag]
   (doseq [filter rss-filters]


### PR DESCRIPTION
1) Removed the "author" tag from each "item".  The presence of this tag is ok here but the xsd requires that the content include a valid email address, not just the name string coming from the site config (Forms that pass validation are "test@xyz.com" or "test@xyz.com (Test McTester)" ).  And who would want to advertise their real email like that?  :)
2) Removed the "author" tag from the "channel".  "author" isn't a valid child element of a channel.  There is a child element called "webMaster" that is a close analogue but it also requires content as above.

Another approach would be to use the "webMaster" tag on the "channel" and document/change the contents of the :author key in config.edn to contain "test@xyz.com (Test McTester)".