### PR TITLE
Optional :date key can be provided in metadata

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -102,7 +102,11 @@
   (let [{:keys [file-name page-meta content]} (page-content page config markup)]
     (merge
       (merge-meta-and-content file-name page-meta content)
-      (let [date (parse-post-date file-name (:post-date-format config))
+      (let [date (if (:date page-meta)
+                   (.parse (java.text.SimpleDateFormat.
+                            (:post-date-format config))
+                            (:date page-meta))
+                   (parse-post-date file-name (:post-date-format config)))
             archive-fmt (java.text.SimpleDateFormat. "yyyy MMMM" (java.util.Locale. "en"))
             formatted-group (.format archive-fmt date)]
         {:date                    date


### PR DESCRIPTION
Following the discussion from [cryogen/#73](https://github.com/cryogen-project/cryogen/issues/73), this change allows posts to override the date from the filename by setting `:date` in the post metadata.

I think this change starts to open up the possibility of having different naming conventions for posts and ultimately support a more flexible and user-defined URL structure.

The `:date` must be in the same format as defined in `config.edn`. I investigated adding support for `#inst` date types but then thought that maybe it should be kept in the same format for now so it is easy for a person to read and edit.