### PR TITLE
Add enclosure tag to facilitate Podcasting with Cryogen

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -143,7 +143,7 @@
   "Adds the uri and title of a post to the list of posts under each of its tags"
   [tags post]
   (reduce (fn [tags tag]
-            (update-in tags [tag] (fnil conj []) (select-keys post [:uri :title :content :date])))
+            (update-in tags [tag] (fnil conj []) (select-keys post [:uri :title :content :date :enclosure])))
           tags (:tags post)))
 
 (defn group-by-tags

--- a/src/cryogen_core/rss.clj
+++ b/src/cryogen_core/rss.clj
@@ -1,18 +1,19 @@
 (ns cryogen-core.rss
   (:require [clj-rss.core :as rss]
-            [clojure.xml :refer [emit]]
             [text-decoration.core :refer :all])
   (:import java.util.Date))
 
 
 (defn posts-to-items [site-url posts]
   (map
-    (fn [{:keys [uri title content date]}]
-      (let [link (str (if (.endsWith site-url "/") (apply str (butlast site-url)) site-url) uri)]
+    (fn [{:keys [uri title content date enclosure]}]
+      (let [link (str (if (.endsWith site-url "/") (apply str (butlast site-url)) site-url) uri)
+            enclosure (if (nil? enclosure) "" enclosure)]
         {:guid        link
          :link        link
          :title       title
          :description content
+         :enclosure   enclosure
          :pubDate     date}))
     posts))
 


### PR DESCRIPTION
Add an enclosure tag to a post's metadata to let a podcast client
to deliver your audio content.  It should look like this:

`:enclosure [{:url "<full-url>"}]`

Without the brackets, you end up with `NullPointerExceptions`, so
make sure you have that.

The URL should be the full location of where the audio file is
hosted (not relative), so for example:

`:enclosure [{:url "http://www.example.com/01_episode_IV.mp3"}]`

I created a bunch of markdown files with just the enclosure and
info about the audiobook with the following bash snippet:

```bash
find -L books -type f -iname "*mp3" | sort | while read mp3; do name=$(basename $mp3 .mp3); book=$(basename "$(dirname $mp3)"); echo "{:title \"$name\"\n:layout :post\n:tags [\"audiobooks\" \"$book\"]\n:enclosure [{:url \"http://clashthebunny.mason.ch/blog/$mp3\"}]}\n $book - $name\n==================" > md/posts/"$(date "+%Y-$name").md"; done
```

Each book was in it's own subdirectory of books:
* books/Dracula/1-01-Chapter1_part01.mp3
* books/Dracula/1-02-Chapter1_part02.mp3
* books/Dracula/2-01-Chapter2_part01.mp3

Note that the above script requires the prefix of the episode to
be "date-like".  It should be fairly easy to work out a way to get
your podcast up and running.

Add the book names to your rss-filters array, e.g.:
`["Dracula" "Pride & Prejudice"]`

Most podcasting clients support authentication, so just password
protect those directories and you should be good to go, even
if you are hosting copyrighted content.