### PR TITLE
Form full TOC structure in hiccup style

### DIFF
--- a/src/cryogen_core/toc.clj
+++ b/src/cryogen_core/toc.clj
@@ -2,9 +2,6 @@
   (:require [crouton.html :as html]
             [hiccup.core :as hiccup]))
 
-(def _h [:h1 :h2 :h3 :h4 :h5 :h6])
-(defn- compare_index [i1 i2] (- (.indexOf _h i2) (.indexOf _h i1)))
-
 (defn- get-headings
   "Turn a body of html content into a vector of elements whose tags are
   headings."
@@ -18,33 +15,38 @@
           headings)))
     [] content))
 
-(defn make-links
-  "Create a table of contents from the given headings. This function will look
-  for either:
+
+(defn- parse [{tag :tag {id :id} :attrs [{{name :name} :attrs} title :as htext] :content}]
+  (hash-map :anchor (or id name)
+            :tag tag 
+            :title (or title (first htext))))
+
+(defn build-toc [hs]
+  "Creates a table of contents from the given headings in form of clojure structure for hiccup. 
+  This function will look  for either:
   (1) headings with a child anchor with a non-nil name attribute, e.g.
       <h1><a name=\"reference\">Reference Title</a></h1>
   or
   (2) headings with an id attribute, e.g. <h1 id=\"reference\">Reference Title</h1>
   In both cases above, the anchor reference becomes \"#reference\" and the
-  anchor text is \"Reference Title\"."
-  [headings]
-  (loop [items headings acc nil _last nil _max (last _h) _first nil]
-    (if-let [{tag :tag {id :id} :attrs [{{name :name} :attrs} title :as htext] :content} (first items)]
-      (let [anchor (or id name)]
-        (if (nil? anchor)
-          (recur (rest items) acc _last _max _first)
-          (let [entry [:li [:a {:href (str "#" anchor)} (or title (first htext))]]
-                jump (if (nil? _first) 0 (compare_index _last tag))
-                m (if (pos? (compare_index tag _max)) tag _max)
-                f (if (nil? _first) tag _first)]
-            (cond (> jump 0) (recur (rest items) (str acc (apply str (repeat jump "<ol>"))
-                                                      (hiccup/html entry)) tag m f)
-                  (= jump 0) (recur (rest items) (str acc (hiccup/html entry)) tag m f)
-                  (< jump 0) (recur (rest items) (str acc (apply str (repeat (* -1 jump) "</ol>"))
-                                                      (hiccup/html entry)) tag m f)))))
-      (str (apply str (repeat (inc (compare_index _max _first)) "<ol>"))
-           acc 
-           (apply str (repeat (inc (compare_index _max _last)) "</ol>"))))))
+  anchor text is \"Reference Title\"."  
+  (let [actual (filterv #(not (nil? (:anchor %))) (map parse (reverse hs))) ;from last to first
+        tags (vec (sort (distinct (map :tag actual))))] ;expecting only h1..h6 tags 
+    (loop [[head & tail] actual toc [:ol.contents ] _prev 0]
+      (let [depth (.indexOf levels (:tag head))
+            entry [:li [:a {:href (str "#" (head :anchor))} (head :title)]]
+            laddr (repeat (min depth _prev) 1)       ;cannot dig more than previous entry level
+            wrap (loop [cnt (max 0 (- depth _prev))  ;add more :ol around entry if we need
+                           acc entry] 
+                      (if (= 0 cnt) acc (recur (dec cnt) (conj [:ol] acc))))
+            add-h #(into [:ol hood] (rest %))        ;add new entry before others
+            ntoc (if (empty? laddr)                  ;on necessary level
+                    (add-h toc)
+                    (update-in toc laddr add-h))] 
+        (if (empty? tail) 
+          ntoc
+          (recur tail ntoc depth))))))
+
 
 (defn generate-toc [html]
   (-> html
@@ -53,5 +55,5 @@
       (html/parse)
       :content
       (get-headings)
-      (make-links)
-      (clojure.string/replace-first #"ol" "ol class=\"contents\"")))
+      (build-toc)
+      (hiccup/html)))

--- a/src/cryogen_core/toc.clj
+++ b/src/cryogen_core/toc.clj
@@ -28,18 +28,23 @@
   In both cases above, the anchor reference becomes \"#reference\" and the
   anchor text is \"Reference Title\"."
   [headings]
-  (loop [items headings acc nil _last nil]
+  (loop [items headings acc nil _last nil _max (last _h) _first nil]
     (if-let [{tag :tag {id :id} :attrs [{{name :name} :attrs} title :as htext] :content} (first items)]
       (let [anchor (or id name)]
         (if (nil? anchor)
-          (recur (rest items) acc nil)
+          (recur (rest items) acc _last _max _first)
           (let [entry [:li [:a {:href (str "#" anchor)} (or title (first htext))]]
-                jump (compare_index _last tag)]
-            (cond (> jump 0) (recur (rest items) (str acc "<ol>" (hiccup/html entry)) tag)
-                  (= jump 0) (recur (rest items) (str acc (hiccup/html entry)) tag)
+                jump (if (nil? _first) 0 (compare_index _last tag))
+                m (if (pos? (compare_index tag _max)) tag _max)
+                f (if (nil? _first) tag _first)]
+            (cond (> jump 0) (recur (rest items) (str acc (apply str (repeat jump "<ol>"))
+                                                      (hiccup/html entry)) tag m f)
+                  (= jump 0) (recur (rest items) (str acc (hiccup/html entry)) tag m f)
                   (< jump 0) (recur (rest items) (str acc (apply str (repeat (* -1 jump) "</ol>"))
-                                                      (hiccup/html entry)) tag)))))
-      (str acc "</ol>"))))
+                                                      (hiccup/html entry)) tag m f)))))
+      (str (apply str (repeat (inc (compare_index _max _first)) "<ol>"))
+           acc 
+           (apply str (repeat (inc (compare_index _max _last)) "</ol>"))))))
 
 (defn generate-toc [html]
   (-> html

--- a/src/cryogen_core/toc.clj
+++ b/src/cryogen_core/toc.clj
@@ -49,6 +49,13 @@
           ntoc
           (recur tail ntoc depth))))))
 
+(defn compact [[t1 & [[t2 & s2] & s1 :as a]]]
+  (if (empty? s1)
+    (if (= :ol t1 t2) 
+      (compact (into [t2] s2))
+      (into [t1] a))
+    (into [t1] (map compact a))))
+
 (defn generate-toc [html]
   (-> html
       (.getBytes "UTF-8")
@@ -57,4 +64,5 @@
       :content
       (get-headings)
       (build-toc)
+      (compact)
       (hiccup/html)))

--- a/src/cryogen_core/toc.clj
+++ b/src/cryogen_core/toc.clj
@@ -2,6 +2,8 @@
   (:require [crouton.html :as html]
             [hiccup.core :as hiccup]))
 
+(def _h [:h1 :h2 :h3 :h4 :h5 :h6])
+
 (defn- get-headings
   "Turn a body of html content into a vector of elements whose tags are
   headings."
@@ -33,20 +35,19 @@
   (let [actual (filterv #(not (nil? (:anchor %))) (map parse (reverse hs))) ;from last to first
         tags (vec (sort (distinct (map :tag actual))))] ;expecting only h1..h6 tags 
     (loop [[head & tail] actual toc [:ol.contents ] _prev 0]
-      (let [depth (.indexOf levels (:tag head))
+      (let [depth (.indexOf tags (:tag head))
             entry [:li [:a {:href (str "#" (head :anchor))} (head :title)]]
             laddr (repeat (min depth _prev) 1)       ;cannot dig more than previous entry level
             wrap (loop [cnt (max 0 (- depth _prev))  ;add more :ol around entry if we need
                            acc entry] 
                       (if (= 0 cnt) acc (recur (dec cnt) (conj [:ol] acc))))
-            add-h #(into [:ol hood] (rest %))        ;add new entry before others
+            add-h #(into [:ol wrap] (rest %))        ;add new entry before others
             ntoc (if (empty? laddr)                  ;on necessary level
                     (add-h toc)
                     (update-in toc laddr add-h))] 
         (if (empty? tail) 
           ntoc
           (recur tail ntoc depth))))))
-
 
 (defn generate-toc [html]
   (-> html


### PR DESCRIPTION
Creates list hierarcy with minimal number of levels, i.e.
h2 h4 h2 h6 goes to 
- h2
 - h4
- h2
 -  
    - h6

unlike to [PR #38] (https://github.com/cryogen-project/cryogen-core/pull/38) where we get 
- h2
 - 
   - h4
- h2
 - 
   - 
     - 
       - h6