### PR TITLE
require pandect.algo.md5 instead of pandect.core

### DIFF
--- a/src/cryogen_core/watcher.clj
+++ b/src/cryogen_core/watcher.clj
@@ -1,7 +1,7 @@
 (ns cryogen-core.watcher
   (:require [clojure.java.io :refer [file]]
             [cryogen-core.io :refer [ignore]]
-            [pandect.core :refer [md5]]
+            [pandect.algo.md5 :refer [md5]]
             [clojure.set :as set]))
 
 (defn get-assets [path ignored-files]


### PR DESCRIPTION
This makes compilation of cryogen-core.watcher faster by reducing the
number of its dependencies. Now it depends just on pandect.algo.md5
instead of all pandect.algo.*