### PR TITLE
Use juxt.dirwatch in cryogen-core.watcher

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
             :license {:name "Eclipse Public License"
                       :url  "http://www.eclipse.org/legal/epl-v10.html"}
             :dependencies [[org.clojure/clojure "1.7.0"]
+                           [juxt/dirwatch "0.2.2"]
                            [clj-rss "0.2.0"]
                            [me.raynes/fs "1.4.6"]
                            [crouton "0.1.2"]


### PR DESCRIPTION
This patch replaces the 300ms loop with a file watcher. juxt.dirwatch is
a wrapper around java.nio.file.WatchService, which provides file watching
functionality implemented natively for platforms JVM is built for.

juxt.dirwatch brings no extra dependencies.

Now rebuilds should be instantaneous.