### PR TITLE
Parallelize read-posts with pmap

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -122,7 +122,7 @@
          (fn [mu]
            (->>
              (find-posts config mu)
-             (map #(parse-post % config mu))))
+             (pmap #(parse-post % config mu))))
          (m/markups))
        (sort-by :date)
        reverse))


### PR DESCRIPTION
This makes each markup implementation process posts in parallel.

In case of a simple test blog with 4 markdown pages mean compilation
time was reduced from 395 to 330ms. In the experiment I used OpenJDK 8
running `lein ring server` on a 4 core CPU.