### PR TITLE
Page/Post/Tag uri customisation 

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -365,7 +365,10 @@
         config
         {:page-root (root-path :page-root config)
          :post-root (root-path :post-root config)
-         :tag-root  (root-path :tag-root config)}))
+         :tag-root  (root-path :tag-root config)
+         :page-root-uri (root-uri :page-root-uri config)
+         :post-root-uri (root-uri :post-root-uri config)
+         :tag-root-uri (root-uri :tag-root-uri congig)}))
     (catch Exception _
       (throw (IllegalArgumentException. "Failed to parse config.edn")))))
 

--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -27,6 +27,13 @@
   (if-let [root (k config)]
     (str "/" root "/") "/"))
 
+(defn root-uri
+  "Creates the uri for posts, tags and pages. Returns root-path by default"
+  [config k]
+  (if-let [uri (k config)]
+    (str "/" uri "/")
+    (root-path ((s/replace k #"-uri^" "")))))
+
 (defn re-pattern-from-ext
   "Creates a properly quoted regex pattern for the given file extension"
   [ext]

--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -23,7 +23,7 @@
 
 (defn root-path
   "Creates the root path for posts, tags and pages"
-  [config k]
+  [k config]
   (if-let [root (k config)]
     (str "/" root "/") "/"))
 

--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -57,13 +57,13 @@
 
 (defn post-uri
   "Creates a post uri from the post file name"
-  [file-name {:keys [blog-prefix post-root]} mu]
-  (str blog-prefix post-root (s/replace file-name (re-pattern-from-ext (m/ext mu)) ".html")))
+  [file-name {:keys [blog-prefix post-root-uri]} mu]
+  (str blog-prefix post-root-uri (s/replace file-name (re-pattern-from-ext (m/ext mu)) ".html")))
 
 (defn page-uri
   "Creates a page uri from the page file name"
-  [page-name {:keys [blog-prefix page-root]} mu]
-  (str blog-prefix page-root (s/replace page-name (re-pattern-from-ext (m/ext mu)) ".html")))
+  [page-name {:keys [blog-prefix page-root-uri]} mu]
+  (str blog-prefix page-root-uri (s/replace page-name (re-pattern-from-ext (m/ext mu)) ".html")))
 
 (defn read-page-meta
   "Returns the clojure map from the top of a markdown page/post"
@@ -174,9 +174,9 @@
 
 (defn tag-info
   "Returns a map containing the name and uri of the specified tag"
-  [{:keys [blog-prefix tag-root]} tag]
+  [{:keys [blog-prefix tag-root-uri]} tag]
   {:name (name tag)
-   :uri  (str blog-prefix tag-root (name tag) ".html")})
+   :uri  (str blog-prefix tag-root-uri (name tag) ".html")})
 
 (defn add-prev-next
   "Adds a :prev and :next key to the page/post data containing the title and uri of the prev/next
@@ -197,10 +197,10 @@
 
 (defn compile-pages
   "Compiles all the pages into html and spits them out into the public folder"
-  [{:keys [blog-prefix page-root] :as params} pages]
+  [{:keys [blog-prefix page-root-uri] :as params} pages]
   (when-not (empty? pages)
     (println (blue "compiling pages"))
-    (create-folder (str blog-prefix page-root))
+    (create-folder (str blog-prefix page-root-uri))
     (doseq [{:keys [uri] :as page} pages]
       (println "\t-->" (cyan uri))
       (spit (str public uri)
@@ -213,10 +213,10 @@
 
 (defn compile-posts
   "Compiles all the posts into html and spits them out into the public folder"
-  [{:keys [blog-prefix post-root disqus-shortname] :as params} posts]
+  [{:keys [blog-prefix post-root-uri disqus-shortname] :as params} posts]
   (when-not (empty? posts)
     (println (blue "compiling posts"))
-    (create-folder (str blog-prefix post-root))
+    (create-folder (str blog-prefix post-root-uri))
     (doseq [post posts]
       (println "\t-->" (cyan (:uri post)))
       (spit (str public (:uri post))
@@ -230,10 +230,10 @@
 
 (defn compile-tags
   "Compiles all the tag pages into html and spits them out into the public folder"
-  [{:keys [blog-prefix tag-root] :as params} posts-by-tag]
+  [{:keys [blog-prefix tag-root-uri] :as params} posts-by-tag]
   (when-not (empty? posts-by-tag)
     (println (blue "compiling tags"))
-    (create-folder (str blog-prefix tag-root))
+    (create-folder (str blog-prefix tag-root-uri))
     (doseq [[tag posts] posts-by-tag]
       (let [{:keys [name uri]} (tag-info params tag)]
         (println "\t-->" (cyan uri))

--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -32,7 +32,7 @@
   [config k]
   (if-let [uri (k config)]
     (str "/" uri "/")
-    (root-path ((s/replace k #"-uri^" "")))))
+    (root-path config (keyword (s/replace k #"-uri^" "")))))
 
 (defn re-pattern-from-ext
   "Creates a properly quoted regex pattern for the given file extension"

--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -369,7 +369,7 @@
          :tag-root  (root-path :tag-root config)
          :page-root-uri (root-uri :page-root-uri config)
          :post-root-uri (root-uri :post-root-uri config)
-         :tag-root-uri (root-uri :tag-root-uri congig)}))
+         :tag-root-uri (root-uri :tag-root-uri config)}))
     (catch Exception _
       (throw (IllegalArgumentException. "Failed to parse config.edn")))))
 

--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -29,10 +29,11 @@
 
 (defn root-uri
   "Creates the uri for posts, tags and pages. Returns root-path by default"
-  [config k]
+  [k config]
   (if-let [uri (k config)]
-    (str "/" uri "/")
-    (root-path config (keyword (s/replace k #"-uri^" "")))))
+    (if-not (s/blank? uri)
+      (str "/" uri "/") "/")
+    (-> k (name) (s/replace #"-uri$" "") (keyword) (root-path config))))
 
 (defn re-pattern-from-ext
   "Creates a properly quoted regex pattern for the given file extension"


### PR DESCRIPTION
Add possibility to configure uri root directory for pages, posts and tags
via config params:
```
:page-root-uri
:post-root-uri
:tag-root-uri
````
- to place entity to the root directory use empty value (ex. :page-root-uri "")
- if parameter is not set corresponding {entity}-root parameter will be used

Issues:
https://github.com/cryogen-project/cryogen-core/issues/32
https://github.com/cryogen-project/cryogen/issues/83

(modification done on last tagged commit 0.1.26 - the HEAD is broken actually, issue created)