### PR TITLE
Fixed a regression under which the old style of using {:toc true} would…

### DIFF
--- a/src/cryogen_core/toc.clj
+++ b/src/cryogen_core/toc.clj
@@ -99,7 +99,8 @@
   contents, while :ul will result in an unordered list. The default is an
   ordered list."
   [^String html & {:keys [list-type] :or {list-type :ol}}]
-  (-> html
+  (let [list-type (if (true? list-type) :ol list-type)]
+    (-> html
     (.getBytes "UTF-8")
     (java.io.ByteArrayInputStream.)
     (html/parse)
@@ -107,4 +108,4 @@
     (get-headings)
     (build-toc-tree)
     (build-toc list-type)
-    (hiccup/html)))
+    (hiccup/html))))

--- a/test/cryogen_core/toc_test.clj
+++ b/test/cryogen_core/toc_test.clj
@@ -93,3 +93,17 @@
                   "but outer headers cannot be less indented "
                   "than the original header."]))
     ))
+
+
+(deftest test-generate-toc
+  (let [htmlString "<div><h2><a name=\"test\"></a>Test</h2></div>"]
+    (is (= "<ol class=\"content\"><li><a href=\"#test\">Test</a></li></ol>"
+               (generate-toc htmlString)))
+    (is (= "<ol class=\"content\"><li><a href=\"#test\">Test</a></li></ol>"
+               (generate-toc htmlString :list-type true)))
+    (is (= "<ol class=\"content\"><li><a href=\"#test\">Test</a></li></ol>"
+               (generate-toc htmlString :list-type :ol)))
+    (is (= "<ul class=\"content\"><li><a href=\"#test\">Test</a></li></ul>"
+               (generate-toc htmlString :list-type :ul)))))
+
+


### PR DESCRIPTION
… throw an exception because the tag was not properly cast to a `:ul` or `:ol` tag. Added unit testing for all cases. Should fix issue #53 which is caused by this issue.