### PR TITLE
Blog/Page/Post/Tag uri customisation

### DIFF
--- a/src/cryogen_core/markup.clj
+++ b/src/cryogen_core/markup.clj
@@ -1,4 +1,5 @@
 (ns cryogen-core.markup
+  (:require [clojure.string :as s])
   (:import java.util.Collections))
 
 (defonce markup-registry (atom []))
@@ -16,7 +17,8 @@
 
   ex. <img src='/img/cryogen.png'/> becomes <img src='/blog/img/cryogen.png'/>"
   [blog-prefix text]
-  (clojure.string/replace text #"href=.?/|src=.?/" #(str (subs % 0 (dec (count %))) blog-prefix "/")))
+  (if-not (s/blank? blog-prefix)
+    (clojure.string/replace text #"href=.?/|src=.?/" #(str (subs % 0 (dec (count %))) "/" blog-prefix "/"))))
 
 (defn markups
   "Return a vector of Markup implementations. This is the primary entry point

--- a/src/cryogen_core/rss.clj
+++ b/src/cryogen_core/rss.clj
@@ -1,6 +1,7 @@
 (ns cryogen-core.rss
   (:require [clj-rss.core :as rss]
-            [text-decoration.core :refer :all])
+            [text-decoration.core :refer :all]
+            [cryogen-core.io :refer [create-file path]])
   (:import java.util.Date))
 
 
@@ -27,8 +28,8 @@
               :lastBuildDate (Date.)})
     (posts-to-items (:site-url config) posts)))
 
-(defn make-filtered-channels [public {:keys [rss-filters blog-prefix] :as config} posts-by-tag]
+(defn make-filtered-channels [{:keys [rss-filters blog-prefix] :as config} posts-by-tag]
   (doseq [filter rss-filters]
-    (let [uri (str public blog-prefix "/" (name filter) ".xml")]
+    (let [uri (path "/" blog-prefix (str (name filter) ".xml"))]
       (println "\t-->" (cyan uri))
-      (spit uri (make-channel config (get posts-by-tag filter))))))
+      (create-file uri (make-channel config (get posts-by-tag filter))))))


### PR DESCRIPTION
Add possibility to configure uri root directory for pages, posts and tags
via config params:
```
:page-root-uri
:post-root-uri
:tag-root-uri
````
- to place entity to the root directory use empty value (ex. :page-root-uri "")
- if parameter is not set corresponding {entity}-root parameter will be used
- set empty blog-prefix to use server root

Issues:
https://github.com/cryogen-project/cryogen-core/issues/32
https://github.com/cryogen-project/cryogen/issues/83

Related PR:
https://github.com/cryogen-project/cryogen/pull/96