### PR TITLE
Fix #58

### DIFF
--- a/src/cryogen_core/markup.clj
+++ b/src/cryogen_core/markup.clj
@@ -16,8 +16,8 @@
   "Injects the blog prefix in front of any local links
     ex. <img src='/img/cryogen.png'/> becomes <img src='/blog/img/cryogen.png'/>"
   [blog-prefix text]
-  (if-not (s/blank? blog-prefix)
-
+  (if (s/blank? blog-prefix)
+    text
     (clojure.string/replace text #"href=.?/|src=.?/" #(str (subs % 0 (dec (count %))) blog-prefix "/"))))
 
 (defn markups


### PR DESCRIPTION
When :blog-prefix in `config.edn` is set nil or "", rewrite-hrefs should return `text` itself.