### PR TITLE
content-with-more-marker returns with correct html closing tags

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -251,7 +251,10 @@
   [^String content]
   (let [index (.indexOf content "<!--more-->")]
     (if (pos? index)
-      (subs content 0 index))))
+      (let [s (subs content 0 index)]
+        (->> ((tagsoup/parse-string s) 2)
+             (drop 2)
+             hiccup/html)))))
 
 (defn create-preview
   "Creates a single post preview"

--- a/test/cryogen_core/compiler_test.clj
+++ b/test/cryogen_core/compiler_test.clj
@@ -1,0 +1,23 @@
+(ns cryogen-core.compiler-test
+  (:require [clojure.test :refer :all]
+            [cryogen-core.compiler :refer :all]))
+
+; Test that the content-until-more-marker return nil or correct html text.
+(deftest test-content-until-more-marker
+  ; text without more marker, return nil
+  (is (nil? (content-until-more-marker "<div id=\"post\">
+  <div class=\"post-content\">
+    this post does not have more marker
+  </div>
+</div>")))
+  ; text with more marker, return text before more marker with closing tags.
+  (is (= (content-until-more-marker "<div id='post'>
+  <div class='post-content'>
+    this post has more marker
+<!--more-->
+and more content.
+  </div>
+</div>")
+         "<div id=\"post\"><div class=\"post-content\">
+    this post has more marker
+</div></div>")))


### PR DESCRIPTION
Using Cryogen with {:previews? true}, the preview page (index.html) corrapsed when post contains more marker.

`content-with-more-marker` returns a HTML string when the `content` conteins more marker ("<!--more-->").

HTML tags in the parameter `content` is balanced.
ex.
````HTML
<div id='post'>
  <div class='post-content'>
    this post has more marker
<!--more-->
and more content.
  </div>
</div>
````

But original code, `content-with-more-marker` function breaks the balance.

result of original code:
````HTML
<div id='post'>
  <div class='post-content'>
    this post has more marker
````

Afer this patch applied, `tagsoup` read above text and `hiccup` re-render to HTML text with correct balanced tags.
````HTML
<div id='post'><div class='post-content'>
    this post has more marker
</div></div>
````
