### PR TITLE
Add author and (short) description for RSS

### DIFF
--- a/src/cryogen_core/rss.clj
+++ b/src/cryogen_core/rss.clj
@@ -7,13 +7,14 @@
 
 (defn posts-to-items [^String site-url posts]
   (map
-    (fn [{:keys [uri title content date enclosure]}]
+    (fn [{:keys [uri title content date enclosure author description]}]
       (let [link (str (if (.endsWith site-url "/") (apply str (butlast site-url)) site-url) uri)
             enclosure (if (nil? enclosure) "" enclosure)]
         {:guid        link
          :link        link
          :title       title
-         :description content
+         :description (or description content)
+         :author      author
          :enclosure   enclosure
          :pubDate     date}))
     posts))


### PR DESCRIPTION
I'm able to add to the post metadata information about the author and a short description of the post, and then use this information in the HTML template (following this [simple approach](https://github.com/cryogen-project/cryogen/issues/30))

Now, I'd also like to have this information in the RSS and this PR is about adding those two values. The author is simply the author, while the description can be either the description specified in the post metadata or the content of the post. This also fit the [specification](http://cyber.law.harvard.edu/rss/rss.html#hrelementsOfLtitemgt): "_...if so its description is a synopsis of the story, and the link points to the full story. An item may also be complete in itself, if so, the description contains the text (entity-encoded HTML is allowed), ..._"

What do you think?