### PR TITLE
Implement clean URLs feature (Issue #89 in cryogen-project/cryogen)

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -267,6 +267,7 @@
                 (render-file "/html/tags.html"
                              (merge params
                                     {:active-page "tags"
+                                     :servlet-context (path "/" blog-prefix "/")
                                      :uri         uri})))))
 
 (defn content-until-more-marker
@@ -354,6 +355,7 @@
                                     {:active-page "archives"
                                      :archives    true
                                      :groups      (group-for-archive posts)
+                                     :servlet-context (path "/" blog-prefix "/")
                                      :uri         uri})))))
 
 (defn compile-authors

--- a/src/cryogen_core/io.clj
+++ b/src/cryogen_core/io.clj
@@ -45,12 +45,16 @@
     []))
 
 (defn create-folder [folder]
-  (let [loc (io/file (str public folder))]
+  (let [loc (io/file (path public folder))]
     (when-not (.exists loc)
       (.mkdirs loc))))
 
 (defn create-file [file data]
-  (spit (str public file) data))
+  (spit (path public file) data))
+
+(defn create-file-recursive [file data]
+  (create-folder (.getParent (io/file file)))
+  (create-file file data))
 
 (defn wipe-public-folder [keep-files]
   (let [filenamefilter (reify java.io.FilenameFilter (accept [this _ filename] (not (some #{filename} keep-files))))]


### PR DESCRIPTION
cryogen-project/cryogen#89

When `clean-urls?` is set in config, emit pages as subdirectories
```
prefix/root/page-name/index.html
```
instead of
```
prefix/root/page-name.html
```
Links in emitted HTML then point to `prefix/root/page-name/`. When `clean-urls?` not set, behaves as
before.

#### Details
Refactor most URI generation into a new `compiler/page-uri` function. `compiler/page-uri` replaces most calls<sup>†</sup> to `io/path`, all calls to `compiler/post-uri` and all calls to the old `compiler/page-uri`.

Introduce function `compiler/write-html`. When `clean-urls?` is set, spits emitted HTML into subdirectories as described above; otherwise behaves like `io/create-file`. Replaces most<sup>†</sup> calls to `io/create-file`.

Introduce function `io/create-file-recursive`. Creates file parent when necessary. Used in `compiler/write-html`.

A little bit of work will need to be done on the [cryogen](https://github.com/cryogen-project/cryogen) project itself; namely, the little development server will need to be changed to serve `index.html` from subdirectories of `blog/`.

<sup>†</sup> Exceptions made for sitemap XML and RSS feed XML pages

## [Demo](http://cqsd.me/demo/)