### PR TITLE
Make archive grouping configurable

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -105,7 +105,7 @@
       (let [date (if (:date page-meta)
                    (.parse (java.text.SimpleDateFormat. (:post-date-format config)) (:date page-meta))
                    (parse-post-date file-name (:post-date-format config)))
-            archive-fmt (java.text.SimpleDateFormat. "yyyy MMMM" (Locale/getDefault))
+            archive-fmt (java.text.SimpleDateFormat. (get config :archive-group-format "yyyy MMMM") (Locale/getDefault))
             formatted-group (.format archive-fmt date)]
         {:date                    date
          :formatted-archive-group formatted-group


### PR DESCRIPTION
The blog that I'm moving to cryogen currently groups the posts by year instead of by year/month. This change makes the grouping configurable while defaulting to the current behavior of year/month grouping on posts.