### PR TITLE
Use Hawk in cryogen-core.watcher

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,4 +13,5 @@
                            [hiccup "1.0.5"]
                            [selmer "1.0.0"]
                            [pandect "0.5.4"]
+                           [hawk "0.2.10"]
                            [clj-tagsoup "0.3.0" :exclusions [org.clojure/clojure]]])

--- a/src/cryogen_core/watcher.clj
+++ b/src/cryogen_core/watcher.clj
@@ -2,6 +2,7 @@
   (:require [clojure.java.io :refer [file]]
             [cryogen-core.io :refer [ignore]]
             [pandect.algo.md5 :refer [md5]]
+            [hawk.core :as hawk]
             [clojure.set :as set]))
 
 (defn get-assets [path ignored-files]
@@ -21,15 +22,15 @@
     (when-some [changes (set/difference new-sum-set old-sum-set)]
       (vals (select-keys new-sums changes)))))
 
-(defn watch-assets [root ignored-files action]
-  (loop [sums (checksums root ignored-files)]
-    (Thread/sleep 300)
-    (let [new-sums (checksums root ignored-files)]
-      (when (find-changes sums new-sums)
-        (action))
-      (recur new-sums))))
+(defn watch-assets [sums root ignored-files action]
+  (let [new-sums (checksums root ignored-files)]
+    (when (find-changes @sums new-sums)
+      (action)
+      (reset! sums new-sums))))
 
 (defn start-watcher! [root ignored-files action]
-  (doto (Thread. #(watch-assets root ignored-files action))
-    (.setDaemon true)
-    (.start)))
+  (let [sums (atom (checksums root ignored-files))
+        handler (fn [ctx e]
+                  (watch-assets sums root ignored-files action))]
+    (hawk/watch! [{:paths  [root]
+                   :handler handler}])))


### PR DESCRIPTION
This is a follow-up to PR #46. It replaces the 300ms loop with a file
watcher. Hawk is a wrapper around java.nio.file.WatchService coming with
proper OS X support.

Now rebuilds should be instantaneous.