### PR TITLE
Fallback to resources/templates/{pages,posts}

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -31,15 +31,30 @@
   [ext]
   (re-pattern (str (s/replace ext "." "\\.") "$")))
 
+(defn find-entries
+  "Returns a list of files under the templates directory according to the
+  implemented Markup protocol and specified root directory. It defaults to
+  looking under the implemented protocol's subdirectory, but fallsback to look
+  at the templates directory."
+  [root mu ignored-files]
+  (let [assets (find-assets (path "templates" (m/dir mu) root)
+                            (m/ext mu)
+                            ignored-files)]
+    (if (seq assets)
+      assets
+      (find-assets (path "templates" root)
+                   (m/ext mu)
+                   ignored-files))))
+
 (defn find-posts
-  "Returns a list of markdown files representing posts under the post root in templates/md"
+  "Returns a list of markdown files representing posts under the post root."
   [{:keys [post-root ignored-files]} mu]
-  (find-assets (path "templates" (m/dir mu) post-root) (m/ext mu) ignored-files))
+  (find-entries post-root mu ignored-files))
 
 (defn find-pages
-  "Returns a list of markdown files representing pages under the page root in templates/md"
+  "Returns a list of markdown files representing pages under the page root."
   [{:keys [page-root ignored-files]} mu]
-  (find-assets (path "templates" (m/dir mu) page-root) (m/ext mu) ignored-files))
+  (find-entries page-root mu ignored-files))
 
 (defn parse-post-date
   "Parses the post date from the post's file name and returns the corresponding java date object"

--- a/test/cryogen_core/compiler_test.clj
+++ b/test/cryogen_core/compiler_test.clj
@@ -1,6 +1,9 @@
 (ns cryogen-core.compiler-test
   (:require [clojure.test :refer :all]
-            [cryogen-core.compiler :refer :all]))
+            [cryogen-core.compiler :refer :all]
+            [cryogen-core.markup :as m]
+            [me.raynes.fs :as fs])
+  (:import [java.io File]))
 
 ; Test that the content-until-more-marker return nil or correct html text.
 (deftest test-content-until-more-marker
@@ -21,3 +24,43 @@ and more content.
          "<div id=\"post\"><div class=\"post-content\">
     this post has more marker
 </div></div>")))
+
+(defn- markdown []
+  (reify m/Markup
+    (dir [this] "md")
+    (ext [this] ".md")))
+
+(defn- create-entry [dir file]
+  (fs/mkdirs (File. dir))
+  (fs/create (File. (str dir File/separator file))))
+
+(defn- reset-resources []
+  (fs/delete-dir "resources")
+  (create-entry "resources" ".gitkeep"))
+
+(defn- check-for-pages [mu]
+  (find-pages {:page-root "pages"} mu))
+
+(defn- check-for-posts [mu]
+  (find-posts {:post-root "posts"} mu))
+
+(deftest test-find-entries
+  (reset-resources)
+  (let [mu (markdown)]
+    (testing "Finds no files"
+      (is (empty? (check-for-posts mu))
+      (is (empty? (check-for-pages mu))))
+
+    (let [dir->file
+          [[check-for-posts "resources/templates/md/posts" "post.md"]
+           [check-for-posts "resources/templates/posts" "post.md"]
+           [check-for-pages "resources/templates/md/pages" "page.md"]
+           [check-for-pages "resources/templates/pages" "page.md"]]]
+      (doseq [[check-fn dir file] dir->file]
+        (testing (str "Finds files in " dir)
+          (create-entry dir file)
+          (let [entries (check-fn mu)]
+            (is (= 1 (count entries)))
+            (is (= (.getAbsolutePath (File. (str dir File/separator file)))
+                   (.getAbsolutePath (first entries)))))
+          (reset-resources)))))))


### PR DESCRIPTION
By default, when using markdown files, Cryogen will look for
`resources/templates/md/pages/*.md`. This commits allows Cryogen to fall back to
`resources/templates/pages/*.md` in the case that it can't find any files in the
former directory. It works similarly for posts and Asciidoc files.

Since we're looking specifically for `*.md` for Markdown files and `*.asc` for
Ascii files, this is an opportunity to eliminate redundancy.