### PR TITLE
support sub directories in pages and posts

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -84,7 +84,8 @@
   the file with the given markup."
   [^java.io.File page config markup]
   (with-open [rdr (java.io.PushbackReader. (reader page))]
-    (let [page-name (.getName page)
+    (let [re-root (re-pattern (str "^.*?(" (:page-root config) "|" (:post-root config) ")/"))
+          page-name (s/replace (str page) re-root "")
           file-name (s/replace page-name (re-pattern-from-ext (m/ext markup)) ".html")
           page-meta (read-page-meta page-name rdr)
           content ((m/render-fn markup) rdr config)]


### PR DESCRIPTION
This commit generates files as follows
```
templates/md/pages/dir/test.md -> public/dir/test/index.html
```
while the current version
```
templates/md/pages/dir/test.md -> public/test/index.html
```
