### PR TITLE
conditionally drop any posts with dates set in the future

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -141,7 +141,8 @@
              (remove #(= (:draft? %) true))))
          (m/markups))
        (sort-by :date)
-       reverse))
+       reverse
+       (drop-while #(and (:hide-future-posts? config) (.after (:date %) (:today config))))))
 
 (defn read-pages
   "Returns a sequence of maps representing the data from markdown files of pages.


### PR DESCRIPTION
This allows users to set a :hide-future-posts? key in their config file to include only current and past blogs in the compiled site. This allows for easy drafting of future articles, and can be used to automatically publish new articles to the static site (provided you recompile of course).

Feel free to change the key name as you wish.

Hope you'll find this useful!