### PR TITLE
enhanced homepage handling & debug option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 .DS*
 /.idea/
 /cryogen-core.iml
+/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ pom.xml.asc
 /.idea/
 /cryogen-core.iml
 /bin/
+/.classpath
+/.project

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cryogen-core "0.1.46"
+(defproject org.domaindrivenarchitecture/cryogen-core "0.1.47-SNAPSHOT"
             :description "Cryogen's compiler"
             :url "https://github.com/cryogen-project/cryogen-core"
             :license {:name "Eclipse Public License"
@@ -14,4 +14,6 @@
                            [selmer "1.10.2"]
                            [pandect "0.6.1"]
                            [hawk "0.2.11"]
-                           [clj-tagsoup "0.3.0" :exclusions [org.clojure/clojure]]])
+                           [clj-tagsoup "0.3.0" :exclusions [org.clojure/clojure]]]
+            :deploy-repositories [["snapshots" :clojars]
+                                  ["releases" :clojars]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.domaindrivenarchitecture/cryogen-core "0.1.47-SNAPSHOT"
+(defproject cryogen-core "0.1.47-SNAPSHOT"
             :description "Cryogen's compiler"
             :url "https://github.com/cryogen-project/cryogen-core"
             :license {:name "Eclipse Public License"

--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -245,13 +245,15 @@
 
 (defn compile-posts
   "Compiles all the posts into html and spits them out into the public folder"
-  [{:keys [blog-prefix post-root-uri disqus-shortname] :as params} posts]
+  [{:keys [blog-prefix post-root-uri disqus-shortname debug?] :as params} posts]
   (when-not (empty? posts)
     (println (blue "compiling posts"))
     (create-folder (path "/" blog-prefix post-root-uri))
     (doseq [post posts]
       (println "\t-->" (cyan (:uri post)))
-      (println "\t-->" (cyan post))
+      (println "\t-->" (cyan debug?))
+      (when debug?
+        (println "\t-->" (cyan post)))
       (write-html (:uri post)
                   params
                   (render-file (str "/html/" (:layout post))
@@ -490,6 +492,8 @@
                        :site-url      (if (.endsWith site-url "/") (.substring site-url 0 (dec (count site-url))) site-url)
                        :theme-path    (str "file:resources/templates/themes/" (:theme config))})]
 
+    (println (blue "debug info"))
+    (println "\t-->" (cyan navbar))
     (set-custom-resource-path! (:theme-path params))
     (wipe-public-folder keep-files)
     (println (blue "copying theme resources"))


### PR DESCRIPTION
Hi,
I added a enhanced homepage handling. You're now able to fund homepage on a page instead of newest post. 

In order to do so, you can add a page containing following meta:
```
{:title "some title"   ;not relevant to feature
 :layout :home        ;other layout may be chosen
 :page-index 0        ;if there are more than one defined homepages
 :home? true          ;relevant meta
}
```

Layout will be respected. 
If you have more than one homepage, the first is chosen. 
Homepages will not be rendered as normal page. 

As I can see, I preserved backward compatibility.

In addition I added a :debug? switch to configuration - so a more verbose output can be triggered.