### PR TITLE
Remove crouton dep because enlive does the same thing

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,6 @@
                            [cheshire "5.6.3"]
                            [clj-rss "0.2.3"]
                            [clj-text-decoration "0.0.3"]
-                           [crouton "0.1.2"]
                            [enlive "1.1.6"]
                            [hawk "0.2.11"]
                            [hiccup "1.0.5"]

--- a/src/cryogen_core/toc.clj
+++ b/src/cryogen_core/toc.clj
@@ -1,6 +1,6 @@
 (ns cryogen-core.toc
   (:require [clojure.zip :as z]
-            [crouton.html :as html]
+            [net.cgrand.enlive-html :as enlive]
             [hiccup.core :as hiccup]))
 
 (def _h [:h1 :h2 :h3 :h4 :h5 :h6])
@@ -102,13 +102,10 @@
   :ol and true will result in an ordered list being generated for the table of
   contents, while :ul will result in an unordered list. The default is an
   ordered list."
-  [^String html & {:keys [list-type] :or {list-type :ol}}]
+  [html & {:keys [list-type] :or {list-type :ol}}]
   (let [list-type (if (true? list-type) :ol list-type)]
     (-> html
-    (.getBytes "UTF-8")
-    (java.io.ByteArrayInputStream.)
-    (html/parse)
-    :content
+    (enlive/html-snippet)
     (get-headings)
     (build-toc-tree)
     (build-toc list-type)

--- a/test/cryogen_core/toc_test.clj
+++ b/test/cryogen_core/toc_test.clj
@@ -1,7 +1,7 @@
 (ns cryogen-core.toc-test
   (:require [clojure.test :refer :all]
             [clojure.string :as s]
-            [crouton.html :as html]
+            [net.cgrand.enlive-html :as enlive]
             [hiccup.core :as hiccup]
             [cryogen-core.toc :refer :all]))
 
@@ -13,7 +13,7 @@
 
 (defn parse-to-headings
   [hiccup-seq]
-  (-> hiccup-seq hiccup/html html/parse-string :content get-headings))
+  (-> hiccup-seq hiccup/html enlive/html-snippet get-headings))
 
 ; Test that the get-headings function properly filters non-headers
 (deftest test-get-headings
@@ -101,5 +101,3 @@
            (generate-toc htmlString :list-type :ol)))
     (is (= "<ul class=\"content\"><li><a href=\"#test\">Test</a></li></ul>"
            (generate-toc htmlString :list-type :ul)))))
-
-


### PR DESCRIPTION
Almost the same thing; it doesn't insert missing html, head and body
tags, but in this case we only care about the stuff in the body.