### PR TITLE
Enable Sass in themes

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -457,8 +457,7 @@
                      (update-in [:tag-root-uri] (fnil str ""))
                      (update-in [:rss-name] (fnil str "rss.xml"))
                      (update-in [:rss-filters] (fnil seq []))
-                     (update-in [:sass-src] (fnil str "css"))
-                     (update-in [:sass-dest] (fnil str "css"))
+                     (update-in [:sass-src] (fnil identity "css"))
                      (update-in [:sass-path] (fnil str "sass"))
                      (update-in [:compass-path] (fnil str "compass"))
                      (update-in [:post-date-format] (fnil str "yyyy-MM-dd"))
@@ -484,7 +483,7 @@
   "Generates all the html and copies over resources specified in the config"
   []
   (println (green "compiling assets..."))
-  (let [{:keys [^String site-url blog-prefix rss-name recent-posts sass-dest keep-files ignored-files previews? author-root-uri theme]
+  (let [{:keys [^String site-url blog-prefix rss-name recent-posts keep-files ignored-files previews? author-root-uri theme]
          :as   config} (read-config)
         posts        (map klipsify (add-prev-next (read-posts config)))
         posts-by-tag (group-by-tags posts)
@@ -519,6 +518,10 @@
 
     (set-custom-resource-path! (str "file:resources/templates/themes/" theme))
     (cryogen-io/wipe-public-folder keep-files)
+    (println (blue "compiling sass"))
+    (sass/compile-sass->css!
+     (merge (select-keys config [:sass-path :compass-path :sass-src :ignored-files])
+            {:base-dir  "resources/templates/"}))
     (println (blue "copying theme resources"))
     (cryogen-io/copy-resources-from-theme config)
     (println (blue "copying resources"))
@@ -542,12 +545,7 @@
     (->> (rss/make-channel config posts)
          (cryogen-io/create-file (cryogen-io/path "/" blog-prefix rss-name)))
     (println (blue "generating filtered rss"))
-    (rss/make-filtered-channels config posts-by-tag)
-    (println (blue "compiling sass"))
-    (sass/compile-sass->css!
-      (merge (select-keys config [:sass-path :compass-path :sass-src :ignored-files])
-             {:sass-dest (cryogen-io/path ".." "public" blog-prefix sass-dest)
-              :base-dir  "resources/templates/"}))))
+    (rss/make-filtered-channels config posts-by-tag)))
 
 (defn compile-assets-timed []
   (time

--- a/src/cryogen_core/io.clj
+++ b/src/cryogen_core/io.clj
@@ -6,7 +6,7 @@
 (def public "resources/public")
 
 (defn path
-  "Creates path from given parts, ignore empty elements" 
+  "Creates path from given parts, ignore empty elements"
   [& path-parts]
   (->> path-parts
        (remove s/blank?)
@@ -77,7 +77,7 @@
           target (path public blog-prefix (fs/base-name resource))]
       (cond
         (not (.exists (io/file src)))
-        (throw (IllegalArgumentException. (str "resource " src " not found")))
+        (or (= resource "css") (throw (IllegalArgumentException. (str "resource " src " not found"))))
         (.isDirectory (io/file src))
         (copy-dir src target ignored-files)
         :else

--- a/src/cryogen_core/io.clj
+++ b/src/cryogen_core/io.clj
@@ -1,6 +1,7 @@
 (ns cryogen-core.io
   (:require [clojure.java.io :as io]
             [clojure.string :as s]
+            [text-decoration.core :refer :all]
             [me.raynes.fs :as fs]))
 
 (def public "resources/public")
@@ -75,6 +76,7 @@
   (doseq [resource resources]
     (let [src (str "resources/templates/" resource)
           target (path public blog-prefix (fs/base-name resource))]
+      (println "\t" (cyan src) "-->" (cyan target))
       (cond
         (not (.exists (io/file src)))
         (throw (IllegalArgumentException. (str "resource " src " not found")))

--- a/src/cryogen_core/io.clj
+++ b/src/cryogen_core/io.clj
@@ -77,7 +77,7 @@
           target (path public blog-prefix (fs/base-name resource))]
       (cond
         (not (.exists (io/file src)))
-        (or (= resource "css") (throw (IllegalArgumentException. (str "resource " src " not found"))))
+        (throw (IllegalArgumentException. (str "resource " src " not found")))
         (.isDirectory (io/file src))
         (copy-dir src target ignored-files)
         :else

--- a/src/cryogen_core/sass.clj
+++ b/src/cryogen_core/sass.clj
@@ -48,18 +48,18 @@
    Sass files but can't find the command. Shows you any problems it
    comes across when compiling. "
   [{:keys [sass-src sass-path ignored-files base-dir] :as opts}]
-  (if (not (coll? sass-src))
-    (recur (assoc opts :sass-src [sass-src]))
-    (doseq [sass-dir sass-src]
-      (when (seq (find-sass-files base-dir sass-dir ignored-files))
-        (if (sass-installed? sass-path)
+  (let [sass-src (if (coll? sass-src) sass-src [sass-src])]
+    (if (and (not (empty? sass-src))
+             (not (sass-installed? sass-path)))
+      (println (red (str "Sass seems not to be installed, but you have scss / sass files in "
+                         sass-src
+                         " - You might want to install it here: sass-lang.com")))
+      (doseq [sass-dir sass-src]
+        (when (seq (find-sass-files base-dir sass-dir ignored-files))
           (do
             (println "\t" (cyan sass-dir) "-->" (cyan sass-dir))
             (let [result (compile-sass-dir! (assoc opts :sass-dir sass-dir))]
               (if (zero? (:exit result))
                 (println "Successfully compiled sass files")
                 (println (red (:err result))
-                         (red (:out result))))))
-          (println "Sass seems not to be installed, but you have scss / sass files in "
-                   sass-dir
-                   " - You might want to install it here: sass-lang.com"))))))
+                         (red (:out result)))))))))))

--- a/src/cryogen_core/sass.clj
+++ b/src/cryogen_core/sass.clj
@@ -23,8 +23,8 @@
       false)))
 
 (defn find-sass-files
-  "Given a Diretory, gets files, Filtered to those having scss or sass
-   extention. Ignores files matching any ignored regexps."
+  "Given a directory, gets files, filtered to those having scss or sass
+   extension. Ignores files matching any ignored regexps."
   [base-dir dir ignored-files]
   (let [^java.io.FilenameFilter filename-filter (cryogen-io/match-re-filter #"(?i:s[ca]ss$)")]
     (->> (.listFiles (io/file base-dir dir) filename-filter)
@@ -32,10 +32,10 @@
          (filter (cryogen-io/ignore ignored-files))
          (map #(.getName ^java.io.File %)))))
 
-(defn compile-sass-file!
-  "Given a sass file which might be in sass-src directory,
-   output the resulting css in the same dir. All error handling is
-   done by sh / launching the sass command."
+(defn compile-sass-dir!
+  "Given a sass directory (or file), output the resulting CSS in the
+   same dir. All error handling is done by sh / launching the sass
+   command."
   [{:keys [sass-dir sass-path compass-path base-dir]}]
   (shell/with-sh-dir base-dir
     (if (compass-installed? compass-path)
@@ -43,9 +43,10 @@
       (sh sass-path "--update" sass-dir))))
 
 (defn compile-sass->css!
-  "Given a directory(s) sass-src, looks for all sass files and compiles them.
-   Prompts you to install sass if it finds sass files but can't find
-   the command. Shows you any problems it comes across when compiling. "
+  "Given a directory or directories in sass-src, looks for all Sass
+   files and compiles them. Prompts you to install sass if it finds
+   Sass files but can't find the command. Shows you any problems it
+   comes across when compiling. "
   [{:keys [sass-src sass-path ignored-files base-dir] :as opts}]
   (if (not (coll? sass-src))
     (recur (assoc opts :sass-src [sass-src]))
@@ -54,7 +55,7 @@
         (if (sass-installed? sass-path)
           (do
             (println "\t" (cyan sass-dir) "-->" (cyan sass-dir))
-            (let [result (compile-sass-file! (assoc opts :sass-dir sass-dir))]
+            (let [result (compile-sass-dir! (assoc opts :sass-dir sass-dir))]
               (if (zero? (:exit result))
                 (println "Successfully compiled sass files")
                 (println (red (:err result))

--- a/src/cryogen_core/sass.clj
+++ b/src/cryogen_core/sass.clj
@@ -34,28 +34,31 @@
 
 (defn compile-sass-file!
   "Given a sass file which might be in sass-src directory,
-   output the resulting css in sass-dest. All error handling is
+   output the resulting css in the same dir. All error handling is
    done by sh / launching the sass command."
-  [{:keys [sass-src sass-dest sass-path compass-path base-dir]}]
+  [{:keys [sass-dir sass-path compass-path base-dir]}]
   (shell/with-sh-dir base-dir
     (if (compass-installed? compass-path)
-      (sh sass-path "--compass" "--update" (str sass-src ":" sass-dest))
-      (sh sass-path "--update" (str sass-src ":" sass-dest)))))
+      (sh sass-path "--compass" "--update" sass-dir)
+      (sh sass-path "--update" sass-dir))))
 
 (defn compile-sass->css!
-  "Given a directory sass-src, looks for all sass files and compiles them into
-   sass-dest. Prompts you to install sass if he finds sass files and can't find
+  "Given a directory(s) sass-src, looks for all sass files and compiles them.
+   Prompts you to install sass if it finds sass files but can't find
    the command. Shows you any problems it comes across when compiling. "
-  [{:keys [sass-src sass-dest sass-path ignored-files base-dir] :as opts}]
-  (when (seq (find-sass-files base-dir sass-src ignored-files))
-    (if (sass-installed? sass-path)
-      (do
-        (println "\t" (cyan sass-src) "-->" (cyan sass-dest))
-        (let [result (compile-sass-file! opts)]
-          (if (zero? (:exit result))
-            (println "Successfully compiled sass files")
-            (println (red (:err result))
-                     (red (:out result))))))
-      (println "Sass seems not to be installed, but you have scss / sass files in "
-               sass-src
-               " - You might want to install it here: sass-lang.com"))))
+  [{:keys [sass-src sass-path ignored-files base-dir] :as opts}]
+  (if (not (coll? sass-src))
+    (recur (assoc opts :sass-src [sass-src]))
+    (doseq [sass-dir sass-src]
+      (when (seq (find-sass-files base-dir sass-dir ignored-files))
+        (if (sass-installed? sass-path)
+          (do
+            (println "\t" (cyan sass-dir) "-->" (cyan sass-dir))
+            (let [result (compile-sass-file! (assoc opts :sass-dir sass-dir))]
+              (if (zero? (:exit result))
+                (println "Successfully compiled sass files")
+                (println (red (:err result))
+                         (red (:out result))))))
+          (println "Sass seems not to be installed, but you have scss / sass files in "
+                   sass-dir
+                   " - You might want to install it here: sass-lang.com"))))))


### PR DESCRIPTION
This also fixed a few inconsistencies in how the `css` directory is handled.

NB: the `:sass-dest` key is no longer used. The code separates Sass compilation from copying files into `public/` so all Sass files are not compiled into their directory.

Fixes #90.

An accompanying change to the Leiningen template repo will ensure there's a `css` directory by default.

There's also some minor text changes, and a little more output about copying resources. I guessed you wouldn't mind those, but let me know if you want to keep the PR simpler.