### PR TITLE
only add enclosure to map if not nil

### DIFF
--- a/src/cryogen_core/rss.clj
+++ b/src/cryogen_core/rss.clj
@@ -8,15 +8,14 @@
 (defn posts-to-items [^String site-url posts]
   (map
     (fn [{:keys [uri title content date enclosure author description]}]
-      (let [link (str (if (.endsWith site-url "/") (apply str (butlast site-url)) site-url) uri)
-            enclosure (if (nil? enclosure) "" enclosure)]
-        {:guid        link
-         :link        link
-         :title       title
-         :description (or description content)
-         :author      author
-         :enclosure   enclosure
-         :pubDate     date}))
+      (let [link (str (if (.endsWith site-url "/") (apply str (butlast site-url)) site-url) uri)]
+        (merge {:guid        link
+                :link        link
+                :title       title
+                :description (or description content)
+                :author      author
+                :pubDate     date}
+               (if enclosure {:enclosure   enclosure}))))
     posts))
 
 (defn make-channel [config posts]


### PR DESCRIPTION
I started using Cyrogen for my blog and it is working very well for me. I appreciate that you made it.

I noticed an issue recently where the feed xml file can be invalid because of a blank <enclosure>. To see this behavior try the following.

Prior to the change this is the report I was receiving: 

```
This feed does not validate.
line 42, column 0: Missing enclosure attribute: length (14 occurrences) [help]
<enclosure>
```
https://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Fblog.bradlucas.com%2Fclojure0.xml

Using my post fix version here I get the following:

https://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Fblog.bradlucas.com%2Fclojure.xml

Let me know what you think. 

Thanks
- Brad
