### PR TITLE
Fix blog-prefix added to protocol-relative url

### DIFF
--- a/src/cryogen_core/markup.clj
+++ b/src/cryogen_core/markup.clj
@@ -17,7 +17,9 @@
   [blog-prefix text]
   (if (string/blank? blog-prefix)
     text
-    (string/replace text #"href=.?/|src=.?/" #(str (subs % 0 (dec (count %))) blog-prefix "/"))))
+    (string/replace text
+                    #"(?!href=.?//)href=.?/|(?!src=.?//)src=.?/"
+                    #(str (subs % 0 (dec (count %))) blog-prefix "/"))))
 
 (defn markups
   "Return a vector of Markup implementations. This is the primary entry point


### PR DESCRIPTION
AsciiDoc has a syntax to embed Youtube video like [this](http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#videos).

This will compiled to an iframe with source to `//www.youtube.com/embed...`

Current regex will break the link by adding blog-prefix to it, changing it to `/blog//www.youtube.com/embed...`

I changed the regex to exclude links that start with double slash.