### PR TITLE
Added theme config ability

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -462,8 +462,16 @@
     (catch Exception e (throw e))))
 
 (defn read-config []
-  (-> "templates/config.edn"
-      cryogen-io/get-resource slurp read-string))
+  (let [config (-> "templates/config.edn"
+                   cryogen-io/get-resource
+                   cryogen-io/read-edn-resource)
+        theme-config-resource (-> config
+                                  :theme
+                                  (#(str "templates/themes/" % "/config.edn"))
+                                  cryogen-io/get-resource)]
+    (if (and (:theme config) theme-config-resource)
+      (merge-with into (cryogen-io/read-edn-resource theme-config-resource) config)
+      config)))
 
 (defn klipsify
   "Add the klipse html under the :klipse key and adds nohighlight

--- a/src/cryogen_core/io.clj
+++ b/src/cryogen_core/io.clj
@@ -23,8 +23,11 @@
 (def match-re-filter (partial re-filter some?))
 (def reject-re-filter (partial re-filter nil?))
 
-(defn get-resource [resource]
-  (-> resource io/resource io/file))
+(defn get-resource [resource-name]
+  (-> resource-name io/resource io/file))
+
+(defn read-edn-resource [resource]
+  (-> resource slurp read-string))
 
 (defn ignore [ignored-files]
   (fn [^java.io.File file]


### PR DESCRIPTION
Added ability for themes to have their own config.edn and specify additional resource and Sass directories.

NB: may want to consider how the merging of theme config works in the long run. It uses `merge-with into` to combine collections, but this will break if someone adds a theme config option that's a scalar. When `overrides` uses `deep-merge`, any key that's not a map is completely replaced by the override; we want to merge things like `:sass-src` and `:resources` though, not replace them.

Let me know if you want this a bit more future-proof.