### PR TITLE
Updated depedencies, including fix for rss feeds newlines

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
             :dependencies [[org.clojure/clojure "1.10.0"]
                            [camel-snake-kebab "0.4.0"]
                            [cheshire "5.8.1"]
-                           [clj-rss "0.2.3"]
+                           [clj-rss "0.2.5"]
                            [clj-text-decoration "0.0.3"]
                            [enlive "1.1.6"]
                            [hawk "0.2.11"]
@@ -15,6 +15,6 @@
                            [me.raynes/fs "1.4.6"]
                            [pandect "0.6.1"]
                            [prismatic/schema "1.1.10"]
-                           [selmer "1.12.9"]]
+                           [selmer "1.12.12"]]
             :deploy-repositories [["snapshots" :clojars]
                                   ["releases" :clojars]])


### PR DESCRIPTION
Hi and thanks for Cryogen!

This PR is specifically to include a fix for `clj-rss` that removes extra newlines which I'd like to see included: https://github.com/yogthos/clj-rss/pull/16 (I know the build failed on the PR but that's because the travis config was updatd on master rather on this branch).

I'm also updating `selmer` because seems to make sense to do it at the same time, but happy to leave that out if you prefer.