### PR TITLE
Clean URLs with and without trailing slash

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -70,9 +70,12 @@
   "Creates a URI from file name. `uri-type` is any of the uri types specified in config, e.g., `:post-root-uri`."
   ([file-name params]
    (page-uri file-name nil params))
-  ([file-name uri-type {:keys [blog-prefix clean-urls?] :as params}]
+  ([file-name uri-type {:keys [blog-prefix clean-urls] :as params}]
    (let [page-uri (get params uri-type)
-         uri-end  (if clean-urls? (string/replace file-name #"(index)?\.html" "") file-name)]
+         uri-end  (condp = clean-urls
+                    :trailing-slash (string/replace file-name #"(index)?\.html" "/")
+                    :no-trailing-slash (string/replace file-name #"(index)?\.html" "")
+                    :dirty file-name)]
      (cryogen-io/path "/" blog-prefix page-uri uri-end))))
 
 (defn read-page-meta
@@ -228,13 +231,20 @@
     (map (partial sort-by :page-index) [navbar-pages sidebar-pages])))
 
 (defn write-html
-  "When `clean-urls?` is set, appends `.html` before spit; otherwise just spits."
-  [file-uri {:keys [clean-urls?]} data]
-  (if clean-urls?
-    (cryogen-io/create-file
-      (if (= "/" file-uri) "index.html" (str file-uri ".html"))
-      data)
-    (cryogen-io/create-file file-uri data)))
+  "When `clean-urls` is set to:
+  - `:trailing-slash` appends `/index.html`.
+  - `:no-trailing-slash` appends `.html`.
+  - `:dirty` just spits."
+  [file-uri {:keys [blog-prefix clean-urls]} data]
+  (condp = clean-urls
+    :trailing-slash (cryogen-io/create-file-recursive
+                     (cryogen-io/path file-uri "index.html") data)
+    :no-trailing-slash (cryogen-io/create-file
+                        (if (or (= blog-prefix file-uri) (= "/" file-uri))
+                          (cryogen-io/path file-uri "index.html")
+                          (str file-uri ".html"))
+                        data)
+    :dirty (cryogen-io/create-file file-uri data)))
 
 (defn- print-debug-info [data]
   (println "DEBUG:")

--- a/src/cryogen_core/schemas.clj
+++ b/src/cryogen_core/schemas.clj
@@ -54,7 +54,9 @@
    :previews?                             s/Bool
    (s/optional-key :posts-per-page)       s/Int
    (s/optional-key :blocks-per-preview)   s/Int
-   :clean-urls?                           s/Bool
+   :clean-urls                            (s/enum :trailing-slash
+                                                  :no-trailing-slash
+                                                  :dirty)
    (s/optional-key :collapse-subdirs?)    s/Bool
    :hide-future-posts?                    s/Bool
    (s/optional-key :klipse)               Klipse

--- a/test/cryogen_core/compiler_test.clj
+++ b/test/cryogen_core/compiler_test.clj
@@ -160,7 +160,7 @@ and more content.
    :posts-per-page       5
    :blocks-per-preview   2
    :previews?            false
-   :clean-urls?          true
+   :clean-urls           :trailing-slash
    :collapse-subdirs?    false
    :hide-future-posts?   true
    :klipse               {}


### PR DESCRIPTION
Full disclosure; I haven't tested this yet. I'll get around to testing it in the next day or so.

This work represents most of the solution I outlined here: https://github.com/cryogen-project/cryogen/issues/166#issuecomment-493294999

Once this branch is confirmed completed and ready to be merged, there are still `clean-urls?` references in [cryogen-project/cryogen](https://github.com/cryogen-project/cryogen) that also need to be addressed as well as documentation updates that will be necessary.