### PR TITLE
WIP Enable users to derive extra params from params + site data

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -468,8 +468,11 @@
    (when-not (empty? overrides)
      (println (yellow "overriding config.edn with:"))
      (pprint overrides))
-   (let [{:keys [^String site-url blog-prefix rss-name recent-posts keep-files ignored-files previews? author-root-uri theme]
-          :as   config} (resolve-config overrides)
+   (let [extend-params (or (:extend-params-fn overrides)
+                           (fn [params _] params))
+         overrides' (dissoc overrides :extend-params-fn)
+         {:keys [^String site-url blog-prefix rss-name recent-posts keep-files ignored-files previews? author-root-uri theme]
+          :as   config} (resolve-config overrides')
          posts        (map klipse/klipsify (add-prev-next (read-posts config)))
          posts-by-tag (group-by-tags posts)
          posts        (tag-posts posts config)
@@ -483,7 +486,7 @@
                            (add-prev-next))
          [navbar-pages
           sidebar-pages] (group-pages other-pages)
-         params       (merge
+         params0      (merge
                        config
                        {:today         (java.util.Date.)
                         :title         (:site-title config)
@@ -499,7 +502,14 @@
                         :index-uri     (page-uri "index.html" config)
                         :tags-uri      (page-uri "tags.html" config)
                         :rss-uri       (cryogen-io/path "/" blog-prefix rss-name)
-                        :site-url      (if (.endsWith site-url "/") (.substring site-url 0 (dec (count site-url))) site-url)})]
+                        :site-url      (if (.endsWith site-url "/") (.substring site-url 0 (dec (count site-url))) site-url)})
+         params       (extend-params
+                        params0
+                        {:posts posts
+                         :pages pages
+                         :posts-by-tag posts-by-tag
+                         :navbar-pages navbar-pages
+                         :sidebar-pages sidebar-pages})]
 
      (set-custom-resource-path! (cryogen-io/path "file:themes" theme))
      (cryogen-io/set-public-path! (:public-dest config))


### PR DESCRIPTION
so that they can f.ex. display a list of tags with their counts.

**NOTE: This is not a finished solution** - it is intended as a base for discussion before I commit too much time [possibly going in the wrong direction] to it. So what do you think, @lacarmen ? 

## ALTERNATIVES

Instead of adding `:extend-params-fn` to the overrides, we could pass it
as an extra param but it is complicated because we need to do it on 2
functions and would then perhaps need to support 3 arities. This seems
simpler.

## TODO / CONSIDER

* Rename `overrides` to something better (what???)
* Use Spec to document the arguments to the extend-params-fn?
* Document extend-params-fn in docstrings and perhaps the site docs?