### PR TITLE
Expose plaintext `description` to pages/posts

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -323,19 +323,20 @@
   [content]
   (when-let [index (string/index-of content "<!--more-->")]
     (->> (subs content 0 index)
-         enlive/html-snippet
-         enlive/emit*
-         (apply str))))
+         enlive/html-snippet)))
+
+(defn preview-dom [blocks-per-preview content]
+  (or (content-until-more-marker content)
+      (->> (enlive/html-snippet content)
+           (take blocks-per-preview))))
 
 (defn create-preview
   "Creates a single post preview"
   [blocks-per-preview post]
   (update post :content
-          #(or (content-until-more-marker %)
-               (->> (enlive/html-snippet %)
-                    (take blocks-per-preview)
-                    enlive/emit*
-                    (apply str)))))
+          #(->> (preview-dom blocks-per-preview %)
+                enlive/emit*
+                (apply str))))
 
 (defn create-previews
   "Returns a sequence of vectors, each containing a set of post previews"
@@ -380,6 +381,22 @@
                                :posts           posts
                                :prev-uri        prev
                                :next-uri        next})))))))
+
+(defn add-description
+  "Add plain text `:description` to the page/post for use in meta description etc."
+  [{:keys [blocks-per-preview description-include-elements]
+    :or   {description-include-elements #{:p :h1 :h2 :h3 :h4 :h5 :h6}}}
+   page]
+  (update
+    page :description
+    #(cond
+       (= false %) nil  ;; if set via page meta to false, do not set
+       %           %    ;; if set via page meta, use it
+       :else       (->> (enlive/select
+                          (preview-dom blocks-per-preview (:content page))
+                          [(set description-include-elements)])
+                        (map enlive/text)
+                        (apply str)))))
 
 (defn compile-index
   "Compiles the index page into html and spits it out into the public folder"
@@ -470,11 +487,16 @@
      (pprint overrides))
    (let [{:keys [^String site-url blog-prefix rss-name recent-posts keep-files ignored-files previews? author-root-uri theme]
           :as   config} (resolve-config overrides)
-         posts        (map klipse/klipsify (add-prev-next (read-posts config)))
+         posts         (->> (read-posts config)
+                            (add-prev-next)
+                            (map klipse/klipsify)
+                            (map (partial add-description config)))
          posts-by-tag (group-by-tags posts)
          posts        (tag-posts posts config)
          latest-posts (->> posts (take recent-posts) vec)
-         pages        (map klipse/klipsify (read-pages config))
+         pages        (->> (read-pages config)
+                           (map klipse/klipsify)
+                           (map (partial add-description config)))
          home-page    (->> pages
                            (filter #(boolean (:home? %)))
                            (first))


### PR DESCRIPTION
so that they can use it in `<meta name=description ..>` and for previews on Fb/Slack/.. e.g.
via `<meta property=og:description ...>`.

The new post/page `:description` is derived from the HTML previews, by default including text from  `p` and `hN` tags.

You want to use it as `{{post.description}}` in a template.

## Updating templates

When this is merged, we should update templates as follows:

```html
<!-- base.html: -->
...
       <title>{{title}}{% block subtitle %}{% endblock %}</title>
        {% block meta %}
        <meta name="description" content="{{description}}">
        <meta name="keywords" content="">
        {% endblock %}
...
<!-- post.html: -->
{% extends "/html/base.html" %}
{%block subtitle %}: {{post.title}}{% endblock %}
{% block meta %}
<meta name="keywords" content="{% for tag in tags %}{{tag.name}}{% if not forloop.last %},{% endif %}{% endfor %}">
{% if post.description %}
<meta name="description" content="{{post.description}}">

{% comment %}{# OpenGraph tags #}{% endcomment %}
<meta property="og:url" content="{{site-url}}{{uri}}" />
<meta property="og:title" content="{{post.title}}" />
<meta property="og:description" content="{{post.description}}">
<meta property="og:type" content="article" />
{% endif %}
{% endblock %}
{% endblock %}
...
<!-- page.html: -->
{% extends "/html/base.html" %}
{% block subtitle %}: {{page.title}}{% endblock %}
{% block meta %}
{% if page.description %}
<meta name="description" content="{{page.description}}">

{% comment %}{# OpenGraph tags #}{% endcomment %}
<meta property="og:url" content="{{site-url}}{{uri}}" />
<meta property="og:title" content="{{page.title}}" />
<meta property="og:description" content="{{page.description}}">
<meta property="og:type" content="article" />
{% endblock %}
...
```

## Updating docs

We need to update the docs to mention that the `:post|:page :description` is available, to document the config option `description-include-elements` and its default of `#{:p :h1 :h2 :h3 :h4 :h5 :h6}`, and to document that you can specify a custom `:description` in the page metadata block or `:description false` to disable it.