### PR TITLE
Fix #193 - default layout values

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -115,7 +115,7 @@
   [page config markup]
   (let [{:keys [file-name page-meta content]} (page-content page config markup)]
     (merge
-      (merge-meta-and-content file-name page-meta content)
+      (merge-meta-and-content file-name (update page-meta :layout #(or % :page)) content)
       {:uri           (page-uri file-name :page-root-uri config)
        :page-index    (:page-index page-meta)
        :klipse/global (:klipse config)
@@ -126,7 +126,7 @@
   [page config markup]
   (let [{:keys [file-name page-meta content]} (page-content page config markup)]
     (merge
-      (merge-meta-and-content file-name page-meta content)
+      (merge-meta-and-content file-name (update page-meta :layout #(or % :post)) content)
       (let [date            (if (:date page-meta)
                               (.parse (java.text.SimpleDateFormat. (:post-date-format config)) (:date page-meta))
                               (parse-post-date file-name (:post-date-format config)))

--- a/src/cryogen_core/schemas.clj
+++ b/src/cryogen_core/schemas.clj
@@ -10,15 +10,15 @@
    (s/optional-key :css-theme) s/Str})
 
 (def MetaData
-  {:layout                      s/Keyword
+  {(s/optional-key :layout)     s/Keyword
    :title                       s/Str
    (s/optional-key :date)       s/Str
    (s/optional-key :author)     s/Str
    (s/optional-key :tags)       [s/Str]
    (s/optional-key :toc)        (s/conditional keyword? (s/enum :ol :ul)
-                                               :else    s/Bool)
+                                               :else s/Bool)
    (s/optional-key :draft?)     s/Bool
-   (s/optional-key :klipse)     (s/conditional map?  Klipse
+   (s/optional-key :klipse)     (s/conditional map? Klipse
                                                :else (s/pred true?))
    (s/optional-key :home?)      s/Bool
    (s/optional-key :page-index) s/Int


### PR DESCRIPTION
Fix cryogen-project/cryogen#193 and default page layout to `:page`, post layout to `:post`.