### PR TITLE
Add :update-article-fn to customize parsed page/..

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -477,29 +477,43 @@
              :ignored-files (map #(re-pattern-from-ext (m/ext %)) (m/markups))}))))
 
 (defn compile-assets
-  "Generates all the html and copies over resources specified in the config"
+  "Generates all the html and copies over resources specified in the config.
+
+  Params:
+   - `overrides-and-hooks` - may contain overrides for `config.edn`; anything
+      here will be available to the page templates, except for these two special
+                parameters:
+     - `:extend-params-fn` - a function (`params`, `site-data`) -> `params` -
+                             use it to derive/add additional params for templates
+     - `:update-article-fn` - a function (`article`, `config`) -> `article` to update a
+                            parsed page/post. Return nil to exclude it."
   ([]
    (compile-assets {}))
-  ([overrides]
+  ([{:keys [extend-params-fn update-article-fn]
+     :or {extend-params-fn (fn [params _] params)
+          update-article-fn identity}
+     :as overrides-and-hooks}]
    (println (green "compiling assets..."))
-   (when-not (empty? overrides)
+   (when-not (empty? overrides-and-hooks)
      (println (yellow "overriding config.edn with:"))
-     (pprint overrides))
-   (let [extend-params (or (:extend-params-fn overrides)
-                           (fn [params _] params))
-         overrides' (dissoc overrides :extend-params-fn)
+     (pprint overrides-and-hooks))
+   (let [overrides     (dissoc overrides-and-hooks :extend-params-fn, :update-article-fn)
          {:keys [^String site-url blog-prefix rss-name recent-posts keep-files ignored-files previews? author-root-uri theme]
-          :as   config} (resolve-config overrides')
+          :as   config} (resolve-config overrides)
          posts         (->> (read-posts config)
                             (add-prev-next)
                             (map klipse/klipsify)
-                            (map (partial add-description config)))
+                            (map (partial add-description config))
+                            (map #(update-article-fn % config))
+                            (remove nil?))
          posts-by-tag (group-by-tags posts)
          posts        (tag-posts posts config)
          latest-posts (->> posts (take recent-posts) vec)
          pages        (->> (read-pages config)
                            (map klipse/klipsify)
-                           (map (partial add-description config)))
+                           (map (partial add-description config))
+                           (map #(update-article-fn % config))
+                           (remove nil?))
          home-page    (->> pages
                            (filter #(boolean (:home? %)))
                            (first))
@@ -525,7 +539,7 @@
                         :tags-uri      (page-uri "tags.html" config)
                         :rss-uri       (cryogen-io/path "/" blog-prefix rss-name)
                         :site-url      (if (.endsWith site-url "/") (.substring site-url 0 (dec (count site-url))) site-url)})
-         params       (extend-params
+         params       (extend-params-fn
                         params0
                         {:posts posts
                          :pages pages
@@ -535,7 +549,7 @@
 
      (set-custom-resource-path! (cryogen-io/path "file:themes" theme))
      (cryogen-io/set-public-path! (:public-dest config))
-     
+
      (cryogen-io/wipe-public-folder keep-files)
      (println (blue "compiling sass"))
      (sass/compile-sass->css! config)
@@ -565,6 +579,7 @@
      (rss/make-filtered-channels config posts-by-tag))))
 
 (defn compile-assets-timed
+  "See the docstring for [[compile-assets]]"
   ([] (compile-assets-timed nil))
   ([config]
    (time
@@ -577,3 +592,12 @@
                 (instance? clojure.lang.ExceptionInfo e))
           (println (red "Error:") (yellow (.getMessage e)))
           (write-exception e)))))))
+
+(comment
+  (def *config (resolve-config {}))
+
+  ;; Build and copy only styles & theme
+  (do
+    (sass/compile-sass->css! *config)
+    (cryogen-io/copy-resources-from-theme *config))
+  nil)


### PR DESCRIPTION
Allow users to supply a function run on every parsed page/post to
update it.

Example uses:

- support for a custom `:slug` metadata in a post to override the defaul
  uri
- post-process the HTML to add self-links to every heading

## NOTE

I struggled to find a good name for "post or page". In the end I have fallen back on the HTML standard and adopted the name it uses for the "main content", i.e. "article". Any better ideas?

## NOTE 2

Notice that while `extend-params-fn` runs very late in the process, this runs very early so it can modify the base data used to create the various site data such as posts and posts-by-tags, while `extend-params-fn` would need to modify all the places where e..g a particular post is used.