### PR TITLE
Fix #131 Replace :content with :content-dom

### DIFF
--- a/src/cryogen_core/rss.clj
+++ b/src/cryogen_core/rss.clj
@@ -1,18 +1,19 @@
 (ns cryogen-core.rss
   (:require [clj-rss.core :as rss]
             [text-decoration.core :refer :all]
-            [cryogen-core.io :as cryogen-io])
+            [cryogen-core.io :as cryogen-io]
+            [cryogen-core.util :as cryogen-util])
   (:import java.util.Date))
 
 
 (defn posts-to-items [^String site-url posts]
   (map
-    (fn [{:keys [uri title content date enclosure author description]}]
+    (fn [{:keys [uri title content-dom date enclosure author description]}]
       (let [link (str (if (.endsWith site-url "/") (apply str (butlast site-url)) site-url) uri)]
         (merge {:guid        link
                 :link        link
                 :title       title
-                :description (or description content)
+                :description description
                 :author      author
                 :pubDate     date}
                (if enclosure {:enclosure   enclosure}))))

--- a/src/cryogen_core/toc.clj
+++ b/src/cryogen_core/toc.clj
@@ -99,9 +99,8 @@
      contents, while :ul will result in an unordered list. The default is an
      ordered list.
    :toc-class will be added to the top-level element (ie. ul.toc-class or ol.toc-class)"
-  [html {:keys [list-type toc-class]}]
+  [html-dom {:keys [list-type toc-class]}]
   (let [list-type (if (true? list-type) :ol list-type)]
-    (-> html
-        (enlive/html-snippet)
+    (-> html-dom
         (generate-toc* list-type toc-class)
         (hiccup/html))))

--- a/src/cryogen_core/util.clj
+++ b/src/cryogen_core/util.clj
@@ -1,5 +1,6 @@
 (ns cryogen-core.util
-  (:require [hiccup.core :as hiccup]))
+  (:require [net.cgrand.enlive-html :as enlive]
+            [hiccup.core :as hiccup]))
 
 (defn filter-html-elems
   "Recursively walks a sequence of enlive-style html elements depth first
@@ -26,6 +27,16 @@
         (sequential? node-or-nodes) (map enlive->hiccup node-or-nodes)
         :else (let [{:keys [tag attrs content]} node-or-nodes]
                 (conj-some [tag] (not-empty attrs) (enlive->hiccup content)))))
+
+(defn enlive->html-text [node-or-nodes]
+  (->> node-or-nodes
+       (enlive/emit*)
+       (apply str)))
+
+(defn enlive->plain-text [node-or-nodes]
+  (->> node-or-nodes
+       (enlive/texts)
+       (apply str)))
 
 (defn hic=
   "Tests whether the xs are equivalent hiccup."

--- a/src/cryogen_core/zip_util.clj
+++ b/src/cryogen_core/zip_util.clj
@@ -1,0 +1,61 @@
+(ns cryogen-core.zip-util
+  "Utils for working with Clojure Zippers"
+  (:require [clojure.zip :as zip]))
+
+(defn remove-rights
+  "Remove all nodes to the right of this one without moving.
+  Modelled after `clojure.zip/insert-right`"
+  [loc]
+  (let [[node {r :r :as path}] loc]
+    (if (nil? path)
+      (throw (new Exception "Remove siblings at top"))
+      (with-meta [node (assoc path :r [] :changed? true)] (meta loc)))))
+
+;; (defn pr-nodes [nodes]
+;;   (->> nodes (map-indexed #(prn %1 ": " (->> (str %2) (take 40) (apply str)))) dorun))
+;;
+;; (defn pr-rights [loc]
+;;   (->> loc zip/rights pr-nodes))
+
+(defn root? [loc] (nil? (zip/path loc)))
+
+(defn remove-rights-til-root [loc]
+  (if (root? loc)
+    loc
+    (recur (try
+             (zip/up (remove-rights loc))
+             (catch Exception e
+               (throw (ex-info (ex-message e) {:loc loc})))))))
+
+(defn find-node
+  "Return the `loc` of the tree that the `pred` returns true for or nil.
+  The pred is invoked with the node (`zip/node`)."
+  [loc pred]
+  (cond
+    (zip/end? loc) nil
+    (pred (zip/node loc)) loc
+    :else (recur (zip/next loc) pred)))
+
+(defn find-nearest-left
+  "Find the nearest left loc of the given `loc`. If it is the leftmost one,
+  search up until you find a node that has a left neighbour. Return nil if none."
+  [loc]
+  (when-not (root? loc)
+    (or (zip/left loc)
+        (recur (zip/up loc)))))
+
+(defn more-marker?
+  "Is the given DOM node the `<!--more-->` marker?"
+  [node]
+  (= node {:type :comment, :data "more"}))
+
+(defn cut-tree-vertically
+  "Given a Zipper, find a node matching the `pred` and cut the tree vertically
+  there (effectively removing all content but closing tags).
+  Returns the root of the tree. Returns nil if `pred` matches nothing."
+  [loc pred]
+  {:pre [loc pred]}
+  (some-> loc
+          (find-node pred)
+          (find-nearest-left)
+          (remove-rights-til-root)))

--- a/test/cryogen_core/compiler_test.clj
+++ b/test/cryogen_core/compiler_test.clj
@@ -10,25 +10,23 @@
 ; Test that the content-until-more-marker return nil or correct html text.
 (deftest test-content-until-more-marker
   ; text without more marker, return nil
-  (is (nil? (content-until-more-marker "<div id=\"post\">
+  (is (nil? (content-until-more-marker (enlive/html-snippet "<div id=\"post\">
   <div class=\"post-content\">
     this post does not have more marker
   </div>
-</div>")))
+</div>"))))
   ; text with more marker, return text before more marker with closing tags.
-  (is (= (->> (content-until-more-marker "<div id='post'>
+  (is (= (->> (content-until-more-marker (enlive/html-snippet "<div id='post'>
   <div class='post-content'>
     this post has more marker
 <!--more-->
 and more content.
   </div>
-</div>")
-              enlive/emit*
-              (apply str))
-         "<div id=\"post\">
+</div>")))
+         (enlive/html-snippet "<div id=\"post\">
   <div class=\"post-content\">
     this post has more marker
-</div></div>")))
+</div></div>"))))
 
 (defn- markdown []
   (reify m/Markup

--- a/test/cryogen_core/klipse_test.clj
+++ b/test/cryogen_core/klipse_test.clj
@@ -1,6 +1,7 @@
 (ns cryogen-core.klipse-test
   (:require [cryogen-core.klipse :refer :all]
-            [clojure.test :refer [deftest testing is are]]))
+            [clojure.test :refer [deftest testing is are]]
+            [net.cgrand.enlive-html :as enlive]))
 
 (deftest map-keys-test
   (is (= {"a" 1 "b" 2} (map-keys name {:a 1 :b 2}))))
@@ -17,9 +18,9 @@
 (deftest code-block-classes-test
   (is (= ["clojure" "ruby"]
          (code-block-classes
-          "<h1>stuff</h1>
+          (enlive/html-snippet "<h1>stuff</h1>
 <div class=\"not-code\"><pre><code class=\"clojure\">(def x 42)</code></pre></div>
-<pre><code class=\"ruby\">123</code><pre>"))))
+<pre><code class=\"ruby\">123</code><pre>")))))
 
 (deftest clojure-eval-classes-test
   (is (= #{"eval-cljs" "eval-reagent"}
@@ -29,14 +30,14 @@
 
 (deftest clojure-eval?-test
   (is (clojure-eval? {"selector" ".eval-cljs"}
-                     "<h1>stuff</h1>
+                     (enlive/html-snippet "<h1>stuff</h1>
 <div class=\"not-code\"><pre><code class=\"eval-cljs\">(def x 42)</code></pre></div>
-<pre><code class=\"ruby\">123</code><pre>"))
+<pre><code class=\"ruby\">123</code><pre>")))
 
   (is (not (clojure-eval? {"selector" ".eval-cljs"
                            "selector_eval_ruby" ".eval-ruby"}
-                          "<h1>stuff</h1>
-<pre><code class=\"eval-ruby\">123</code><pre>"))))
+                          (enlive/html-snippet "<h1>stuff</h1>
+<pre><code class=\"eval-ruby\">123</code><pre>")))))
 
 (deftest normalize-settings-test
   (is (= {"selector_reagent" ".reagent"

--- a/test/cryogen_core/toc_test.clj
+++ b/test/cryogen_core/toc_test.clj
@@ -92,10 +92,10 @@
       "Supports nested tags in headings."))
 
 (deftest test-generate-toc
-  (let [htmlString "<div><h2 id=\"test\">Test</h2></div>"]
+  (let [html-dom (enlive/html-snippet "<div><h2 id=\"test\">Test</h2></div>")]
     (is (= "<ol class=\"toc\"><li><a href=\"#test\">Test</a></li></ol>"
-           (generate-toc htmlString {:list-type true :toc-class "toc"})))
+           (generate-toc html-dom {:list-type true :toc-class "toc"})))
     (is (= "<ol class=\"toc\"><li><a href=\"#test\">Test</a></li></ol>"
-           (generate-toc htmlString {:list-type :ol :toc-class "toc"})))
+           (generate-toc html-dom {:list-type :ol :toc-class "toc"})))
     (is (= "<ul class=\"custom-toc\"><li><a href=\"#test\">Test</a></li></ul>"
-           (generate-toc htmlString {:list-type :ul :toc-class "custom-toc"})))))
+           (generate-toc html-dom {:list-type :ul :toc-class "custom-toc"})))))

--- a/test/cryogen_core/util_test.clj
+++ b/test/cryogen_core/util_test.clj
@@ -23,3 +23,11 @@
             (enlive->hiccup {:tag :div,
                              :attrs {:class "foo"},
                              :content '({:tag :p :content "bar"})}))))
+
+(deftest enlive->html-text-test
+  (is (= (enlive->html-text (enlive/html-snippet "<p>hi <b>there</b>!</p>"))
+         "<p>hi <b>there</b>!</p>")))
+
+(deftest enlive->plain-text-test
+  (is (= (enlive->plain-text (enlive/html-snippet "<h1>Greeting:</h1><p>hi <b>there</b>!</p>"))
+         "Greeting:hi there!")))

--- a/test/cryogen_core/zip_util_test.clj
+++ b/test/cryogen_core/zip_util_test.clj
@@ -1,0 +1,38 @@
+(ns cryogen-core.zip-util-test
+  (:require [clojure.test :refer :all]
+            [clojure.zip :as z]
+            [net.cgrand.enlive-html :as enlive]
+            [cryogen-core.zip-util :refer :all]))
+
+(def tree [1 [21 22 23] 3])
+
+(defn treez [] (z/vector-zip tree))
+
+(defn html-zipper [s]
+  (z/xml-zip {:content (enlive/html-snippet s)}))
+
+(deftest find-nearest-left-test
+  (is (= (z/node (find-nearest-left (find-node (treez) #{22})))
+         21))
+  (is (= (z/node (find-nearest-left (find-node (treez) #{21})))
+         1))
+  (is (nil? (find-nearest-left (find-node (treez) #{1})))))
+
+(deftest more-marker?-test
+  (is (= (-> (find-node
+               (html-zipper "<div><p>first</p><p>second<!--more--></p></div><p>after</p>")
+               more-marker?)
+             (z/left)
+             (z/node))
+         "second")))
+
+(deftest cut-tree-vertically-test
+  (is (nil? (cut-tree-vertically (treez) #{1})))
+  (is (nil? (cut-tree-vertically (treez) #{:no-such-node})))
+  (is (= (z/node (cut-tree-vertically (treez) #{21}))
+         [1]))
+  (is (= (z/node (cut-tree-vertically (treez) #{22}))
+         [1 [21]]))
+  (is (= (z/node (cut-tree-vertically (treez) #{23}))
+         [1 [21 22]])))
+


### PR DESCRIPTION
passing around the Enlive DOM tree instead of the final HTML text
so that it is easier to work with both for us and users, instead of
repeatedly transforming text<>dom.