### PR TITLE
Upgrade outdated dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject cryogen-core "0.3.0"
+(defproject cryogen-core "0.3.1-SNAPSHOT"
             :description "Cryogen's compiler"
             :url "https://github.com/cryogen-project/cryogen-core"
             :license {:name "Eclipse Public License"
                       :url  "http://www.eclipse.org/legal/epl-v10.html"}
             :dependencies [[org.clojure/clojure "1.10.0"]
-                           [camel-snake-kebab "0.4.0"]
-                           [cheshire "5.8.1"]
+                           [camel-snake-kebab "0.4.1"]
+                           [cheshire "5.9.0"]
                            [clj-rss "0.2.5"]
                            [clj-text-decoration "0.0.3"]
                            [enlive "1.1.6"]
@@ -14,7 +14,7 @@
                            [io.aviso/pretty "0.1.37"]
                            [me.raynes/fs "1.4.6"]
                            [pandect "0.6.1"]
-                           [prismatic/schema "1.1.10"]
-                           [selmer "1.12.12"]]
+                           [prismatic/schema "1.1.12"]
+                           [selmer "1.12.18"]]
             :deploy-repositories [["snapshots" :clojars]
                                   ["releases" :clojars]])

--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -7,7 +7,6 @@
             [net.cgrand.enlive-html :as enlive]
             [schema.core :as s]
             [selmer.parser :refer [cache-off!]]
-            [selmer.util :refer [set-custom-resource-path!]]
             [text-decoration.core :refer :all]
             [cryogen-core.io :as cryogen-io]
             [cryogen-core.config :refer [resolve-config]]
@@ -580,7 +579,8 @@
                          :navbar-pages navbar-pages
                          :sidebar-pages sidebar-pages})]
 
-     (set-custom-resource-path! (cryogen-io/path "file:themes" theme))
+     (selmer.parser/set-resource-path!
+       (.getAbsolutePath ^java.io.File (io/as-file (cryogen-io/path "themes" theme))))
      (cryogen-io/set-public-path! (:public-dest config))
 
      (cryogen-io/wipe-public-folder keep-files)


### PR DESCRIPTION
Upgrade outdated dependencies as per the GH [Dependencies Status](https://versions.deps.co/cryogen-project/cryogen-core) report: [![Dependencies Status](https://versions.deps.co/cryogen-project/cryogen-core/status.svg)](https://versions.deps.co/cryogen-project/cryogen-core)

NOTE: I have now tested it on my blog. It was OK, I only had to fix the Selmer config.