### PR TITLE
Fix: a page will correctly render its content when set as homepage 

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -444,12 +444,11 @@
                 params
                 (render-file (str "/html/" (:layout home-page))
                              (merge params
-                                    {:active-page    "home"
-                                     :home           true
-                                     :selmer/context (cryogen-io/path "/" blog-prefix "/")
-                                     :uri            uri
-                                     :post           home-page
-                                     :page           home-page})))))
+                                    {:active-page       "home"
+                                     :home              true
+                                     :selmer/context    (cryogen-io/path "/" blog-prefix "/")
+                                     :uri               uri
+                                     (:type home-page)  home-page})))))
 
 (defn compile-archives
   "Compiles the archives page into html and spits it out into the public folder"

--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -131,7 +131,8 @@
   (let [{:keys [file-name page-meta content-dom]} (page-content page config markup)]
     (-> (merge-meta-and-content file-name (update page-meta :layout #(or % :page)) content-dom)
         (merge
-          {:uri           (page-uri file-name :page-root-uri config)
+          {:type          :page
+           :uri           (page-uri file-name :page-root-uri config)
            :page-index    (:page-index page-meta)
            :klipse/global (:klipse config)
            :klipse/local  (:klipse page-meta)})
@@ -148,7 +149,8 @@
           formatted-group (.format archive-fmt date)]
       (-> (merge-meta-and-content file-name (update page-meta :layout #(or % :post)) content-dom)
           (merge
-            {:date                    date
+            {:type                    :post
+             :date                    date
              :formatted-archive-group formatted-group
              :parsed-archive-group    (.parse archive-fmt formatted-group)
              :uri                     (page-uri file-name :post-root-uri config)


### PR DESCRIPTION
Resolves #135 

Introduces a new `:type` key to post/page maps

Slight problem: neither `read-page-meta` function nor `MetaData` spec distinguishes between pages and posts. I have not therefore updated the spec with a `:type` key.

What's the intended direction here - do y'all want a stricter distinction between pages/posts, or are they meant to stay ambiguous?