### PR TITLE
fix #109: parse post dates when posts are stored in subdirectories

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -64,7 +64,9 @@
   "Parses the post date from the post's file name and returns the corresponding java date object"
   [^String file-name date-fmt]
   (let [fmt (java.text.SimpleDateFormat. date-fmt)]
-    (.parse fmt (.substring file-name 0 10))))
+    (if-let [last-slash (string/last-index-of file-name "/")]
+      (.parse fmt (.substring file-name (inc last-slash) (+ last-slash 11)))
+      (.parse fmt (.substring file-name 0 10)))))
 
 
 (defn page-uri


### PR DESCRIPTION
This should fix the scenario described in the #109 