### PR TITLE
Add ability to compile html

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -451,6 +451,21 @@
                                      :uri               uri
                                      (:type home-page)  home-page})))))
 
+(defn compile-additional-html
+  [{:keys [blog-prefix compile-html] :as params}]
+  (doseq [html-file compile-html]
+    (println "-->" (cyan html-file))
+    ; set `:clean-urls` to `:dirty` to get the correct uri, e.g.: /404.html
+    (let [params-html (assoc params :clean-urls :dirty)
+          uri (page-uri (str html-file ".html") params-html)]
+      (write-html uri
+                  params-html
+                  (render-file (str "/html/" html-file ".html")
+                               (merge params-html
+                                      {:active-page    html-file
+                                       :selmer/context (cryogen-io/path "/" blog-prefix "/")
+                                       :uri            uri}))))))
+
 (defn compile-archives
   "Compiles the archives page into html and spits it out into the public folder"
   [{:keys [blog-prefix] :as params} posts]
@@ -533,7 +548,8 @@
      (println (yellow "overriding config.edn with:"))
      (pprint overrides-and-hooks))
    (let [overrides    (dissoc overrides-and-hooks :extend-params-fn :update-article-fn)
-         {:keys [^String site-url blog-prefix rss-name recent-posts keep-files ignored-files previews? author-root-uri theme]
+         {:keys [^String site-url blog-prefix rss-name recent-posts keep-files
+                 ignored-files previews? author-root-uri theme compile-html copy-html]
           :as   config} (resolve-config overrides)
          posts        (->> (read-posts config)
                            (add-prev-next)
@@ -580,7 +596,8 @@
                          :pages pages
                          :posts-by-tag posts-by-tag
                          :navbar-pages navbar-pages
-                         :sidebar-pages sidebar-pages})]
+                         :sidebar-pages sidebar-pages})
+         copy-html-full-paths (map #(str "html/" % ".html") copy-html)]
 
      (selmer.parser/set-resource-path!
        (.getAbsolutePath ^java.io.File (io/as-file (cryogen-io/path "themes" theme))))
@@ -589,8 +606,11 @@
      (cryogen-io/wipe-public-folder keep-files)
      (println (blue "compiling sass"))
      (sass/compile-sass->css! config)
+     (when compile-html
+       (println (blue "compiling additional html"))
+       (compile-additional-html params))
      (println (blue "copying theme resources"))
-     (cryogen-io/copy-resources-from-theme config)
+     (cryogen-io/copy-resources-from-theme config copy-html-full-paths)
      (println (blue "copying resources"))
      (cryogen-io/copy-resources "content" config)
      (copy-resources-from-markup-folders config)

--- a/src/cryogen_core/io.clj
+++ b/src/cryogen_core/io.clj
@@ -95,12 +95,12 @@
 
 (defn copy-resources-from-theme
   "Copy resources from theme"
-  [config]
+  [config additional-resources]
   (copy-resources
    (path "themes" (:theme config))
    (merge config
           {:resources (concat
-                       ["css"
-                        "js"
-                        "html/404.html"]
+                        ["css"
+                         "js"]
+                       additional-resources
                        (:theme-resources config))})))

--- a/src/cryogen_core/schemas.clj
+++ b/src/cryogen_core/schemas.clj
@@ -61,4 +61,6 @@
    (s/optional-key :hide-future-posts?)   s/Bool
    (s/optional-key :klipse)               Klipse
    (s/optional-key :debug?)               s/Bool
+   (s/optional-key :copy-html)            [s/Str]
+   (s/optional-key :compile-html)         [s/Str]
    s/Keyword                              s/Any})


### PR DESCRIPTION
While migrating my blog from Jekyll to Cryogen, I've encountered a few scenarios I wanted Cryogen to support. If they could be useful to others, I'd love to push them upstream.

## Scenario 

I'd like to have my 404 page, for example, to retain all the usual navigation elements from my base.html. See examples [here](https://harryrschwartz.com/not-found), [here](https://alexeyzabelin.com/not-found) and [here](https://danplisetsky.github.io/not-found)

## Changes

This pull request adds the ability to compile (i.e., to run through selmer's `render-file`) random html files as specified by the user. 

## Breaking change?

No, since the additional keys are optional and the [default value](https://github.com/cryogen-project/cryogen-core/compare/master...danplisetsky:compile-html?expand=1#diff-871a38f4ed20c2418c10405d416f2762R35) of :copy-html replicates old behaviour.

## Docs

Docs will require updating. Specifically, the [configuration](http://cryogenweb.org/docs/configuration.html) page and the [directory structure](http://cryogenweb.org/docs/structure.html) page that shows the diagram with 404.html not extending base.html

## Note

I'm new to Clojure, so any notes on how to make this pull request better are appreciated!

@lacarmen What do you think?