### PR TITLE
Parse page and post content via selmer

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -275,8 +275,10 @@
 (defn htmlize-content [params]
   (cond
     (contains? params :posts) (update params :posts (partial map content-dom->html))
-    (contains? params :post) (update params :post content-dom->html)
-    (contains? params :page) (update params :page content-dom->html)
+    (contains? params :post) (-> (update params :post content-dom->html)
+                                 (update-in [:post :content] selmer.parser/render params))
+    (contains? params :page) (-> (update params :page content-dom->html)
+                                 (update-in [:page :content] selmer.parser/render params))
     :else params))
 
 (defn render-file

--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -273,13 +273,16 @@
       (assoc :content (util/enlive->html-text dom))))
 
 (defn htmlize-content [params]
-  (cond
-    (contains? params :posts) (update params :posts (partial map content-dom->html))
-    (contains? params :post) (-> (update params :post content-dom->html)
+  (let [parse-content? (:parse-content-with-selmer? params)]
+    (cond
+      (contains? params :posts) (update params :posts (partial map content-dom->html))
+      (contains? params :post) (cond-> (update params :post content-dom->html)
+                                 parse-content?
                                  (update-in [:post :content] selmer.parser/render params))
-    (contains? params :page) (-> (update params :page content-dom->html)
+      (contains? params :page) (cond-> (update params :page content-dom->html)
+                                 parse-content?
                                  (update-in [:page :content] selmer.parser/render params))
-    :else params))
+      :else params)))
 
 (defn render-file
   "Wrapper around `selmer.parser/render-file` with pre-processing"

--- a/src/cryogen_core/config.clj
+++ b/src/cryogen_core/config.clj
@@ -31,6 +31,7 @@
                      (update-in [:sass-path] (fnil identity "sass"))
                      (update-in [:posts-per-page] (fnil identity 5))
                      (update-in [:blocks-per-preview] (fnil identity 2))
+                     (update-in [:parse-content-with-selmer?] (fnil identity false))
                      (assoc :page-root-uri (root-uri :page-root-uri config)
                             :post-root-uri (root-uri :post-root-uri config)))
           check-overlap (fn [dirs]

--- a/src/cryogen_core/schemas.clj
+++ b/src/cryogen_core/schemas.clj
@@ -61,4 +61,5 @@
    (s/optional-key :hide-future-posts?)   s/Bool
    (s/optional-key :klipse)               Klipse
    (s/optional-key :debug?)               s/Bool
+   (s/optional-key :parse-content-with-selmer?) s/Bool
    s/Keyword                              s/Any})

--- a/test/cryogen_core/config_test.clj
+++ b/test/cryogen_core/config_test.clj
@@ -36,7 +36,8 @@
    :hide-future-posts?           true
    :klipse                       {}
    :description-include-elements #{:p :h1 :h2 :h3 :h4 :h5 :h6}
-   :debug?                       false})
+   :debug?                       false
+   :parse-content-with-selmer?   false})
 
 (deftest test-config-parsing
   (testing "Parsing configuration file"


### PR DESCRIPTION
(cont. from #138)

Another feature that I wanted to see (which actually exists in Jekyll) is being able to template not only html but md content, too.

## Scenario

I have my email in `config.edn`. I want to show it on my [Contact](https://danplisetsky.github.io/contact/) page. 

## Changes

This pull request adds the ability to use Selmer templating engine in content files. The scenario above is now doable: 

`contact.md`
```html
 <i class="fas fa-envelope"></i> {{ email|email }}
```

## Breaking change?

Potentially, but it's unlikely that many have been using Selmer's syntax verbatim in their content files. Still, it's a **breaking change**.

## Docs

Docs will require updating to reflect this new change.