### PR TITLE
Fixed resource path bug on Windows.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cryogen-core "0.3.1"
+(defproject cryogen-core "0.3.2"
             :description "Cryogen's compiler"
             :url "https://github.com/cryogen-project/cryogen-core"
             :license {:name "Eclipse Public License"

--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -583,7 +583,7 @@
                          :sidebar-pages sidebar-pages})]
 
      (selmer.parser/set-resource-path!
-       (.getAbsolutePath ^java.io.File (io/as-file (cryogen-io/path "themes" theme))))
+       (util/file->url (io/as-file (cryogen-io/path "themes" theme))))
      (cryogen-io/set-public-path! (:public-dest config))
 
      (cryogen-io/wipe-public-folder keep-files)

--- a/src/cryogen_core/util.clj
+++ b/src/cryogen_core/util.clj
@@ -55,3 +55,8 @@
   "Tests whether the xs are equivalent hiccup."
   [x & xs]
   (apply = (map #(hiccup/html %) (cons x xs))))
+
+(defn file->url
+  "Converts a java.io.File to a java.net.URL."
+  [^java.io.File f]
+  (.. f (getAbsoluteFile) (toURI) (toURL)))


### PR DESCRIPTION
The trick is to use `File#getAbsoluteFile` instead of `File#getAbsolutePath` and then getting a `java.net.URL` from that. Otherwise, the path will start with a drive letter. Selmer is looking for absolute paths starting with "/" or "file:/". The approach taken in this patch avoids having to do some sort of absolute path matching (regex) for Windows-style paths in Selmer.