### PR TITLE
Fix 142: URL encode tag links

### DIFF
--- a/test/cryogen_core/compiler_test.clj
+++ b/test/cryogen_core/compiler_test.clj
@@ -131,3 +131,17 @@ and more content.
           invalid-metadata (reader-string "{:layout \"post\" :title \"Hello World\"}")]
       (is (read-page-meta nil valid-metadata))
       (is (thrown? Exception (read-page-meta nil invalid-metadata))))))
+
+(deftest tags-are-url-encoded
+  (testing "URL encode tags"
+    (let [config {:tag-root-uri "tags-output" :blog-prefix "/blog" :clean-urls :trailing-slash}]
+    (are [expected tag] (= expected (:uri (tag-info config tag)))
+                        "/blog/tags-output/a-tag/" "a-tag"
+                        "/blog/tags-output/c%23/" "c#"
+                        "/blog/tags-output/why%3F/" "why?"
+                        "/blog/tags-output/with%20a%20space/" "with a space")
+    (are [expected tag] (= expected (:file-path (tag-info config tag)))
+                        "/blog/tags-output/a-tag/" "a-tag"
+                        "/blog/tags-output/c#/" "c#"
+                        "/blog/tags-output/why?/" "why?"
+                        "/blog/tags-output/with a space/" "with a space"))))


### PR DESCRIPTION
Tags which contain special characters like a # or ? produce a link which doesn't reach the tag output page. Fix: URL encode the tag in the links