### PR TITLE
Hawk library fails in macOS Big Sur Preview

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cryogen-core "0.3.1"
+(defproject cryogen-core "0.3.2"
             :description "Cryogen's compiler"
             :url "https://github.com/cryogen-project/cryogen-core"
             :license {:name "Eclipse Public License"


### PR DESCRIPTION
https://github.com/cryogen-project/cryogen/issues/218

hawk/watch! fails trying to load Carbon lib on macOS
Big Sur preview due to changes in the OS and dynamic
linking. I was able to work around it for now by catching
the error and defaulting to file system polling instead.