### PR TITLE
Allow multiple extensions in Markup.

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -27,10 +27,10 @@
 
 (def content-root "content")
 
-(defn re-pattern-from-ext
-  "Creates a properly quoted regex pattern for the given file extension"
-  [ext]
-  (re-pattern (str (string/replace ext "." "\\.") "$")))
+(defn re-pattern-from-exts
+  "Creates a properly quoted regex pattern for the given file extensions"
+  [exts]
+  (re-pattern (str "(" (string/join "|" (map #(string/replace % "." "\\.") exts)) ")$")))
 
 (defn find-entries
   "Returns a list of files under the content directory according to the
@@ -40,13 +40,13 @@
   [root mu ignored-files]
   (let [assets (cryogen-io/find-assets
                  (cryogen-io/path content-root (m/dir mu) root)
-                 (m/ext mu)
+                 (m/exts mu)
                  ignored-files)]
     (if (seq assets)
       assets
       (cryogen-io/find-assets
         (cryogen-io/path content-root root)
-        (m/ext mu)
+        (m/exts mu)
         ignored-files))))
 
 (defn find-posts
@@ -99,7 +99,7 @@
     (let [re-root     (re-pattern (str "^.*?(" (:page-root config) "|" (:post-root config) ")/"))
           page-fwd    (string/replace (str page) "\\" "/")  ;; make it work on Windows
           page-name   (if (:collapse-subdirs? config) (.getName page) (string/replace page-fwd re-root ""))
-          file-name   (string/replace page-name (re-pattern-from-ext (m/ext markup)) ".html")
+          file-name   (string/replace page-name (re-pattern-from-exts (m/exts markup)) ".html")
           page-meta   (read-page-meta page-name rdr)
           content     ((m/render-fn markup) rdr config)
           content-dom (util/trimmed-html-snippet content)]
@@ -509,7 +509,7 @@
      content-root
      (merge config
             {:resources     folders
-             :ignored-files (map #(re-pattern-from-ext (m/ext %)) (m/markups))}))))
+             :ignored-files (map #(re-pattern-from-exts (m/exts %)) (m/markups))}))))
 
 (defn compile-assets
   "Generates all the html and copies over resources specified in the config.

--- a/src/cryogen_core/io.clj
+++ b/src/cryogen_core/io.clj
@@ -42,15 +42,16 @@
 
 (defn find-assets
   "Find all assets in the given root directory (f) and the given file
-  extension (ext) ignoring any files that match the given (ignored-files).
+  extensions (exts) ignoring any files that match the given (ignored-files).
   First make sure that the root directory exists, if yes: process as normal;
-  if no, return empty vector."
-  [f ^String ext ignored-files]
+  if no, return empty vector.
+  exts is a set of strings (for multiple alternative extensions)."
+  [f exts ignored-files]
   (if-let [root (get-resource f)]
     (->> (get-resource f)
          file-seq
          (filter (ignore ignored-files))
-         (filter (fn [^java.io.File file] (-> file .getName (.endsWith ext)))))
+         (filter (fn [^java.io.File file] (some #(.endsWith (.getName file) %) exts))))
     []))
 
 (defn create-folder [folder]

--- a/src/cryogen_core/markup.clj
+++ b/src/cryogen_core/markup.clj
@@ -5,10 +5,10 @@
 
 (defprotocol Markup
   "A markup engine comprising a dir(ectory) containing markup files,
-  an ext(ension) for finding markup file names, and a render-fn that returns
+  a set of exts (extensions) for finding markup file names, and a render-fn that returns
   a fn with the signature [java.io.Reader config] -> String (HTML)."
   (dir [this])
-  (ext [this])
+  (exts [this])             ; should return a set of extension strings
   (render-fn [this]))
 
 (defn rewrite-hrefs

--- a/src/cryogen_core/sitemap.clj
+++ b/src/cryogen_core/sitemap.clj
@@ -19,7 +19,7 @@
       {:tag :urlset
        :attrs {:xmlns "http://www.sitemaps.org/schemas/sitemap/0.9"}
        :content
-       (for [^java.io.File f (cryogen-io/find-assets cryogen-io/public ".html" ignored-files)]
+       (for [^java.io.File f (cryogen-io/find-assets cryogen-io/public #{".html"} ignored-files)]
          {:tag :url
           :content
           [{:tag :loc

--- a/test/cryogen_core/compiler_test.clj
+++ b/test/cryogen_core/compiler_test.clj
@@ -31,12 +31,12 @@ and more content.
 (defn- markdown []
   (reify m/Markup
     (dir [this] "md")
-    (ext [this] ".md")))
+    (exts [this] #{".md"})))
 
 (defn- asciidoc []
   (reify m/Markup
     (dir [this] "asc")
-    (ext [this] ".asc")))
+    (exts [this] #{".asc"})))
 
 (defn- create-entry [dir file]
   (fs/mkdirs (File. dir))
@@ -87,12 +87,13 @@ and more content.
   the Markup implementation's `dir` in the path. Check that the folders exist
   in the output folder."
   [[pages-root posts-root :as dirs] mu with-dir?]
-  (doseq [dir dirs]
+  (doseq [dir dirs
+          ext (m/exts mu)]
     (let [path (if with-dir?
                  (str (m/dir mu) "/" dir)
                  dir)]
       (create-entry (str "content/" path)
-                    (str "entry" (m/ext mu)))))
+                    (str "entry" ext))))
   (with-markup mu
                (copy-resources-from-markup-folders
                  {:post-root   posts-root


### PR DESCRIPTION
Here are a set of PRs that implement multiple filename extensions in Markup.
Prompted by Issue  Number 6 in the `cryogen-asciidoc` repo.

Related PRs are

- `cryogen-asciidoc` PR number 7
- `cryogen-docs` PR number 32
- `cryogen-markdown` PR number 13
- `cryogen-flexmark` PR number 6

