### PR TITLE
Allow certain paths to be excluded from the sitemap

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -606,7 +606,7 @@
        (println (blue "generating authors views"))
        (compile-authors params posts))
      (println (blue "generating site map"))
-     (->> (sitemap/generate site-url ignored-files)
+     (->> (sitemap/generate site-url config)
           (cryogen-io/create-file (cryogen-io/path "/" blog-prefix "sitemap.xml")))
      (println (blue "generating main rss"))
      (->> (rss/make-channel config posts)

--- a/src/cryogen_core/io.clj
+++ b/src/cryogen_core/io.clj
@@ -40,6 +40,12 @@
           matches (map #(re-find % name) ignored-files)]
       (not (some seq matches)))))
 
+(defn ignore-path [ignored-paths]
+  (fn [^java.io.File file]
+    (let [path    (.getPath file)
+          matches (map #(re-find % path) ignored-paths)]
+      (not (some seq matches)))))
+
 (defn find-assets
   "Find all assets in the given root directory (f) and the given file
   extensions (exts) ignoring any files that match the given (ignored-files).

--- a/src/cryogen_core/sitemap.clj
+++ b/src/cryogen_core/sitemap.clj
@@ -13,20 +13,14 @@
 (defn loc [^java.io.File f]
   (-> f (.getAbsolutePath) (.split (cryogen-io/path cryogen-io/public "/")) second))
 
-(defn ignore-path [ignored-paths]
-  (fn [^java.io.File file]
-    (let [path    (.getPath file)
-          matches (map #(re-find % path) ignored-paths)]
-      (not (some seq matches)))))
-
-(defn generate [site-url {:keys [ignored-files ignored-paths]}]
+(defn generate [site-url {:keys [ignored-files sitemap-ignored-paths]}]
   (with-out-str
     (emit
       {:tag :urlset
        :attrs {:xmlns "http://www.sitemaps.org/schemas/sitemap/0.9"}
        :content
        (for [^java.io.File f (->> (cryogen-io/find-assets cryogen-io/public #{".html"} ignored-files)
-                                  (filter (ignore-path ignored-paths)))]
+                                  (filter (cryogen-io/ignore-path sitemap-ignored-paths)))]
          {:tag :url
           :content
           [{:tag :loc


### PR DESCRIPTION
The compiler now passes the whole `config` map into `sitemap/generate` and that destructures `ignored-files` and a new optional key `ignored-paths` and filters the latter out of the result of the `find-assets` call.

The `ignore-path` function mirrors the `ignore-name` function in `cryogen-core.io` -- should it perhaps be in that ns in case other code might want to reuse it later?

Is the new config key `:ignore-paths` a good choice? Should it be something sitemap-specific (since only `sitemap/generate` uses it)?