### PR TITLE
Enable postprocessing of article HTML

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cryogen-core "0.3.2"
+(defproject cryogen-core "0.4.0"
             :description "Cryogen's compiler"
             :url "https://github.com/cryogen-project/cryogen-core"
             :license {:name "Eclipse Public License"


### PR DESCRIPTION
... right before the article is written to the disk.

Add `:postprocess-article-html-fn` config option that will be called on the article
(page/post) after it is transformed from markup to HTML.

This can be used e.g. to run it through Selmer so that you can use Selmer templating
in your markup and get it processed - see #139 for the original request for that.