### PR TITLE
Simplify the contrib/release docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,23 +8,17 @@ There is also an active community on the `#cryogen` channel on the
 ## Bug reports and Issues
 
 If you find a bug or if you want to suggest an enhancement, please
-open an Issue on Github under the appropriate repo.
+open an Issue on GitHub under the appropriate repo.
 
 ## Pull Requests
 
 If you want to fix a bug or address an issue:
 
-1. Please fork the repo to your individual account on Github.
-2. Clone that repo to your own machine.
-3. Create a feature branch on that repo.
-4. Fix the bug/issue on that feature branch.
-5. Push the feature branch back to your forked repo on Github.
-6. Open a Pull Request (PR) back to this repo.
-
-Alternatively, especially if the changes are small, limited to one
-file, and you have write access to the repo, you can make the changes
-directly on Github, but please make a new branch and open a PR as
-above.
+1. Preferably, fork the repo to your individual account on GitHub.
+2. Create a feature branch on the repo.
+3. Fix the bug/issue on that feature branch.
+4. Push the feature branch.
+5. Open a Pull Request (PR) to merge the change into this repo's master.
 
 Please mention the open bug issue number within your PR if
 applicable.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,17 +25,13 @@ elapsed time basis.  Typically once there are significant changes.
 
 Note this uses `0.1.12` as an example new release number.
 
-1. Create a release branch on your local repo of your fork of this
-  repo on Github.
+1. Create a release branch.
   ```
   git checkout master
   git pull
   git checkout -b release-0.1.12
   git push -u origin release-0.1.12
   ```
-  Alternatively, if you have write access to the repo, make a new
-  branch on the repo and make the changes directly on Github and
-  create a PR.
 2. Update [CHANGELOG.md](CHANGELOG.md)
   * Write the release highlights in the `Unreleased` section.
   * Add a section for the new release just under the `Unreleased` section.
@@ -44,17 +40,15 @@ Note this uses `0.1.12` as an example new release number.
     version.
 3. Update the version in [project.clj](project.clj).
 4. Update any version numbers in [README.md](README.md).
-5. Push changes to your fork on Github.
+5. Push changes to GitHub.
   ```
   git add .
   git commit -m "Prepare release 0.1.12"
   git push origin
   ```
-  Alternatively, if you have made the changes directly on Github,
-  there is nothing further to do.
-6. Create a pull request. 
-7. Merge the pull request into the primary repo on Github.
-8. Tag the new commit on Github with the new release number (e.g.,
+6. Create a pull request.
+7. Merge the pull request into the primary repo on GitHub.
+8. Tag the new commit on GitHub with the new release number (e.g.,
    `0.1.12`).
 9. Publish the release to Clojars.
 10. Update the version in [project.clj](project.clj) to next snapshot


### PR DESCRIPTION
* Do not mandate but do recommend creating a fork
* Leave out details that most GH users know so that the important
information is more visible.