### PR TITLE
Fail if extend-params-fn adds :posts

### DIFF
--- a/src/cryogen_core/compiler.clj
+++ b/src/cryogen_core/compiler.clj
@@ -651,6 +651,10 @@
                          :navbar-pages navbar-pages
                          :sidebar-pages sidebar-pages})]
 
+     (assert (not (and (:posts params) (not (:posts params0))))
+             (str "Sorry, you cannot add `:posts` to params because this is"
+                  " used internally at some places. Pick a different keyword."))
+
      (selmer.parser/set-resource-path!
        (util/file->url (io/as-file (cryogen-io/path "themes" theme))))
      (cryogen-io/set-public-path! (:public-dest config))


### PR DESCRIPTION
because 1) it would break rendering of posts and pages due to the order
of the cond clauses in `htmlize-content`
2) even if we changed the order so that posts is last (which seems to
work fine) it would still not work as expected because some pages
define :posts themselves, overriding this - e.g. tag pages.

The best solution is thus tell the user not to do this and use another key instead.

Fixes #156