### PR TITLE
fix(toc): nested lists should go in parent `li`

### DIFF
--- a/src/cryogen_core/toc.clj
+++ b/src/cryogen_core/toc.clj
@@ -78,10 +78,9 @@
                    (when outer-list?
                      {:class toc-class})
                    (map #(build-toc % list-type toc-class {:outer-list? false}) children)]]
-        (list li
-              (if outer-list?
-                inner
-                [:li inner])))
+        (if outer-list?
+          (list li inner)
+          (conj li inner)))
       li))) ; Or just return the naked :li tag
 
 (defn generate-toc*

--- a/test/cryogen_core/toc_test.clj
+++ b/test/cryogen_core/toc_test.clj
@@ -55,10 +55,11 @@
       "No outer header should be less indented than the first header tag.")
 
   (is (util/hic= [:ul.toc
-                  [:li [:a {:href "#starting_low"} "Starting Low"]]
-                  [:li [:ul
-                        [:li [:a {:href "#jumping_in"} "Jumping Right In"]]
-                        [:li [:a {:href "#pulling_back"} "But then pull back"]]]]
+                  [:li
+                   [:a {:href "#starting_low"} "Starting Low"]
+                   [:ul
+                    [:li [:a {:href "#jumping_in"} "Jumping Right In"]]
+                    [:li [:a {:href "#pulling_back"} "But then pull back"]]]]
                   [:li [:a {:href "#to_the_top"} "To the top"]]]
                  (-> [:div
                       [:h2 {:id "starting_low"}


### PR DESCRIPTION
Apparently I'm really bad at reading code/documentation. It should actually look like this:

```html
<ol>
	<li>Header 1
		<ol>
			<li>Subheader 1</li>
		</ol>
	</li>
</ol>
```

Really sorry for submitting a borked pr. And this time I made sure to test it on my own site to see that it works with `:resource-paths ["cryogen-core-0.4.8-standalone.jar"]`. Proof:

<img width="261" height="219" alt="image" src="https://github.com/user-attachments/assets/ef67d898-9196-4cf5-800d-fe0a03485ac5" />

ref: #176 